### PR TITLE
feat: add SdpTransformUtil

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -527,8 +527,9 @@ JitsiConference.prototype.replaceTrack = function (oldTrack, newTrack) {
         }
         // Set up the ssrcHandler for the new track before we add it at the lower levels
         newTrack.ssrcHandler = function (conference, ssrcMap) {
-            if (ssrcMap[this.getMSID()]) {
-                this._setSSRC(ssrcMap[this.getMSID()]);
+            const trackSSRCInfo = ssrcMap.get(this.getMSID());
+            if (trackSSRCInfo) {
+                this._setSSRC(trackSSRCInfo);
                 conference.rtc.removeListener(
                     RTCEvents.SENDRECV_STREAMS_CHANGED,
                     this.ssrcHandler);
@@ -1039,7 +1040,7 @@ function (jingleSession, jingleOffer, now) {
     this.rtc.initializeDataChannels(jingleSession.peerconnection);
     // Add local Tracks to the ChatRoom
     this.getLocalTracks().forEach(function(localTrack) {
-        var ssrcInfo = null;
+        let ssrcInfo = null;
         /**
          * We don't do this for Firefox because, on Firefox, we keep the
          *  stream in the peer connection and just set 'enabled' on the
@@ -1070,7 +1071,8 @@ function (jingleSession, jingleOffer, now) {
             ssrcInfo = {
                 mtype: localTrack.getType(),
                 type: "addMuted",
-                ssrc: localTrack.ssrc,
+                ssrcs: localTrack.ssrc.ssrcs,
+                groups: localTrack.ssrc.groups,
                 msid: localTrack.initialMSID
             };
         }

--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -370,18 +370,17 @@ JitsiLocalTrack.prototype._addStreamToConferenceAsUnmute = function () {
         return Promise.resolve();
     }
 
-    var self = this;
-
-    return new Promise(function(resolve, reject) {
-        self.conference._addLocalStream(
-            self.stream,
+    return new Promise((resolve, reject) => {
+        this.conference._addLocalStream(
+            this.stream,
             resolve,
             (error) => reject(new Error(error)),
             {
-                mtype: self.type,
+                mtype: this.type,
                 type: "unmute",
-                ssrc: self.ssrc,
-                msid: self.getMSID()
+                ssrcs: this.ssrc && this.ssrc.ssrcs,
+                groups: this.ssrc && this.ssrc.groups,
+                msid: this.getMSID()
             });
     });
 };
@@ -406,7 +405,8 @@ function (successCallback, errorCallback) {
         {
             mtype: this.type,
             type: "mute",
-            ssrc: this.ssrc
+            ssrcs: this.ssrc && this.ssrc.ssrcs,
+            groups: this.ssrc && this.ssrc.groups
         });
 };
 
@@ -422,11 +422,9 @@ JitsiLocalTrack.prototype._sendMuteStatus = function(mute) {
         return Promise.resolve();
     }
 
-    var self = this;
-
-    return new Promise(function(resolve) {
-        self.conference.room[
-            self.isAudioTrack()
+    return new Promise((resolve) => {
+        this.conference.room[
+            this.isAudioTrack()
                 ? 'setAudioMute'
                 : 'setVideoMute'](mute, resolve);
     });
@@ -521,7 +519,7 @@ JitsiLocalTrack.prototype._setConference = function(conference) {
  */
 JitsiLocalTrack.prototype.getSSRC = function () {
     if(this.ssrc && this.ssrc.groups && this.ssrc.groups.length)
-        return this.ssrc.groups[0].primarySSRC;
+        return this.ssrc.groups[0].ssrcs[0];
     else if(this.ssrc && this.ssrc.ssrcs && this.ssrc.ssrcs.length)
         return this.ssrc.ssrcs[0];
     else

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -1431,16 +1431,15 @@ export default class JingleSessionPC extends JingleSession {
                     ssrcObj.mtype + "\"]>description");
                 if (!desc || !desc.length)
                     return;
-                ssrcObj.ssrc.ssrcs.forEach(function (ssrc) {
+                ssrcObj.ssrcs.forEach(function (ssrc) {
                     const sourceNode = desc.find(">source[ssrc=\"" +
                         ssrc + "\"]");
                     sourceNode.remove();
                 });
-                ssrcObj.ssrc.groups.forEach(function (group) {
+                ssrcObj.groups.forEach(function (group) {
                     const groupNode = desc.find(">ssrc-group[semantics=\"" +
-                        group.group.semantics + "\"]:has(source[ssrc=\"" +
-                        group.primarySSRC +
-                        "\"])");
+                        group.semantics + "\"]:has(source[ssrc=\"" +
+                        group.ssrcs[0] + "\"])");
                     groupNode.remove();
                 });
             });
@@ -1454,7 +1453,7 @@ export default class JingleSessionPC extends JingleSession {
                     = JingleSessionPC.createDescriptionNode(
                         jingle, ssrcObj.mtype);
                 const cname = Math.random().toString(36).substring(2);
-                ssrcObj.ssrc.ssrcs.forEach(function (ssrc) {
+                ssrcObj.ssrcs.forEach(function (ssrc) {
                     const sourceNode
                         = desc.find(">source[ssrc=\"" + ssrc + "\"]");
                     sourceNode.remove();
@@ -1468,18 +1467,18 @@ export default class JingleSessionPC extends JingleSession {
                         "</source>";
                     desc.append(sourceXML);
                 });
-                ssrcObj.ssrc.groups.forEach(function (group) {
+                ssrcObj.groups.forEach(function (group) {
                     const groupNode
                         = desc.find(">ssrc-group[semantics=\"" +
-                            group.group.semantics + "\"]:has(source[ssrc=\""
-                            + group.primarySSRC + "\"])");
+                            group.semantics + "\"]:has(source[ssrc=\""
+                            + group.ssrcs[0] + "\"])");
                     groupNode.remove();
                     desc.append(
-                        "<ssrc-group semantics=\"" + group.group.semantics +
+                        "<ssrc-group semantics=\"" + group.semantics +
                         "\" xmlns=\"urn:xmpp:jingle:apps:rtp:ssma:0\">" +
                         "<source ssrc=\"" +
-                            group.group.ssrcs.split(" ")
-                                .join("\"/>" + "<source ssrc=\"") + "\"/>" +
+                            group.ssrcs.join("\"/>" + "<source ssrc=\"") +
+                            "\"/>" +
                         "</ssrc-group>");
                 });
             });
@@ -1497,20 +1496,20 @@ export default class JingleSessionPC extends JingleSession {
         this.modifiedSSRCs["mute"] = [];
         if (ssrcs && ssrcs.length)
             ssrcs.forEach(function (ssrcObj) {
-                ssrcObj.ssrc.ssrcs.forEach(function (ssrc) {
+                ssrcObj.ssrcs.forEach(function (ssrc) {
                     const sourceNode
                         = $(jingle.tree()).find(">jingle>content[name=\"" +
                             ssrcObj.mtype + "\"]>description>source[ssrc=\"" +
                             ssrc + "\"]");
                     sourceNode.remove();
                 });
-                ssrcObj.ssrc.groups.forEach(function (group) {
+                ssrcObj.groups.forEach(function (group) {
                     const groupNode
                         = $(jingle.tree()).find(
                             ">jingle>content[name=\"" + ssrcObj.mtype +
                             "\"]>description>ssrc-group[semantics=\"" +
-                            group.group.semantics + "\"]:has(source[ssrc=\"" +
-                            group.primarySSRC + "\"])");
+                            group.semantics + "\"]:has(source[ssrc=\"" +
+                            group.ssrcs[0] + "\"])");
                     groupNode.remove();
                 });
             });
@@ -1522,7 +1521,7 @@ export default class JingleSessionPC extends JingleSession {
                 const desc
                     = JingleSessionPC.createDescriptionNode(
                         jingle, ssrcObj.mtype);
-                ssrcObj.ssrc.ssrcs.forEach(function (ssrc) {
+                ssrcObj.ssrcs.forEach(function (ssrc) {
                     const sourceNode
                         = desc.find(">source[ssrc=\"" + ssrc + "\"]");
                     if (!sourceNode || !sourceNode.length) {
@@ -1533,18 +1532,18 @@ export default class JingleSessionPC extends JingleSession {
                             "ssrc=\"" + ssrc + "\"></source>");
                     }
                 });
-                ssrcObj.ssrc.groups.forEach(function (group) {
+                ssrcObj.groups.forEach(function (group) {
                     const groupNode
                         = desc.find(">ssrc-group[semantics=\"" +
-                            group.group.semantics + "\"]:has(source[ssrc=\"" +
-                            group.primarySSRC + "\"])");
+                            group.semantics + "\"]:has(source[ssrc=\"" +
+                            group.ssrcs[0] + "\"])");
                     if (!groupNode || !groupNode.length) {
                         desc.append("<ssrc-group semantics=\"" +
-                            group.group.semantics +
+                            group.semantics +
                             "\" xmlns=\"urn:xmpp:jingle:apps:rtp:ssma:0\">" +
                             "<source ssrc=\"" +
-                                group.group.ssrcs.split(" ")
-                                    .join("\"/><source ssrc=\"") + "\"/>" +
+                                group.ssrcs.join("\"/><source ssrc=\"") +
+                                "\"/>" +
                             "</ssrc-group>");
                     }
                 });

--- a/modules/xmpp/RtxModifier.js
+++ b/modules/xmpp/RtxModifier.js
@@ -1,116 +1,62 @@
+/* global __filename */
+
 import { getLogger } from "jitsi-meet-logger";
-const logger = getLogger(__filename);
-import * as transform from 'sdp-transform';
+import { parseSecondarySSRC, SdpTransformWrap  } from './SdpTransformUtil';
 import * as SDPUtil from "./SDPUtil";
+
+const logger = getLogger(__filename);
 
 /**
  * Begin helper functions
  */
 /**
- * Given a videoMLine, returns a list of the video
- *  ssrcs (those used to actually send video, not
- *  any associated secondary streams)
- * @param {object} videoMLine media line object from transform.parse
- * @returns {list<string>} list of primary video ssrcs
- */
-function getPrimaryVideoSsrcs (videoMLine) {
-    let videoSsrcs = videoMLine.ssrcs
-        .map(ssrcInfo => ssrcInfo.id)
-        .filter((ssrc, index, array) => array.indexOf(ssrc) === index);
-
-    if (videoMLine.ssrcGroups) {
-        videoMLine.ssrcGroups.forEach((ssrcGroupInfo) => {
-            // Right now, FID groups are the only ones we parse to 
-            //  disqualify streams.  If/when others arise we'll
-            //  need to add support for them here
-            if (ssrcGroupInfo.semantics === "FID") {
-                // secondary FID streams should be filtered out
-                let secondarySsrc = ssrcGroupInfo.ssrcs.split(" ")[1];
-                videoSsrcs.splice(
-                  videoSsrcs.indexOf(parseInt(secondarySsrc)), 1);
-            }
-        });
-    }
-    return videoSsrcs;
-}
-
-/**
- * Given a video mline (as parsed from transform.parse),
- *  and a primary ssrc, return the corresponding rtx ssrc
- *  (if there is one) for that video ssrc
- * @param {object} videoMLine the video MLine from which to extract the
- *  rtx video ssrc
- * @param {number} primarySsrc the video ssrc for which to find the
- *  corresponding rtx ssrc
- * @returns {number} the rtx ssrc (or undefined if there isn't one)
- */
-function getRtxSsrc (videoMLine, primarySsrc) {
-    if (videoMLine.ssrcGroups) {
-        let fidGroup = videoMLine.ssrcGroups.find(group => {
-            if (group.semantics === "FID") {
-                let groupPrimarySsrc = SDPUtil.parseGroupSsrcs(group)[0];
-                return groupPrimarySsrc === primarySsrc;
-            }
-        });
-        if (fidGroup) {
-          return SDPUtil.parseGroupSsrcs(fidGroup)[1];
-        }
-    }
-}
-
-/**
  * Updates or inserts the appropriate rtx information for primarySsrc with
  *  the given rtxSsrc.  If no rtx ssrc for primarySsrc currently exists, it will
  *  add the appropriate ssrc and ssrc group lines.  If primarySsrc already has
  *  an rtx ssrc, the appropriate ssrc and group lines will be updated
- * @param {object} videoMLine video mline object that will be updated (in place)
- * @param {object} primarySsrcInfo the info (ssrc, msid & cname) for the 
+ * @param {MLineWrap} mLine
+ * @param {object} primarySsrcInfo the info (ssrc, msid & cname) for the
  *  primary ssrc
  * @param {number} rtxSsrc the rtx ssrc to associate with the primary ssrc
  */
-function updateAssociatedRtxStream (videoMLine, primarySsrcInfo, rtxSsrc) {
-    logger.debug("Updating mline to associate " + rtxSsrc + 
-        " rtx ssrc with primary stream ", primarySsrcInfo.id);
-    let primarySsrc = primarySsrcInfo.id;
-    let primarySsrcMsid = primarySsrcInfo.msid;
-    let primarySsrcCname = primarySsrcInfo.cname;
+function updateAssociatedRtxStream (mLine, primarySsrcInfo, rtxSsrc) {
+    logger.debug(
+        `Updating mline to associate ${rtxSsrc}` +
+        `rtx ssrc with primary stream, ${primarySsrcInfo.id}`);
+    const primarySsrc = primarySsrcInfo.id;
+    const primarySsrcMsid = primarySsrcInfo.msid;
+    const primarySsrcCname = primarySsrcInfo.cname;
 
-    let previousAssociatedRtxStream = 
-        getRtxSsrc (videoMLine, primarySsrc);
-    if (previousAssociatedRtxStream === rtxSsrc) {
-        logger.debug(rtxSsrc + " was already associated with " +
-            primarySsrc);
+    const previousRtxSSRC = mLine.getRtxSSRC(primarySsrc);
+    if (previousRtxSSRC === rtxSsrc) {
+        logger.debug(`${rtxSsrc} was already associated with ${primarySsrc}`);
         return;
     }
-    if (previousAssociatedRtxStream) {
-        logger.debug(primarySsrc + " was previously assocaited with rtx " +
-            previousAssociatedRtxStream + ", removing all references to it");
+    if (previousRtxSSRC) {
+        logger.debug(
+            `${primarySsrc} was previously associated with rtx` +
+            `${previousRtxSSRC}, removing all references to it`);
+
         // Stream already had an rtx ssrc that is different than the one given,
         //  remove all trace of the old one
-        videoMLine.ssrcs = videoMLine.ssrcs
-            .filter(ssrcInfo => ssrcInfo.id !== previousAssociatedRtxStream);
-        logger.debug("groups before filtering for " + 
-            previousAssociatedRtxStream);
-        logger.debug(JSON.stringify(videoMLine.ssrcGroups));
-        videoMLine.ssrcGroups = videoMLine.ssrcGroups
-            .filter(groupInfo => {
-                return groupInfo
-                    .ssrcs
-                    .indexOf(previousAssociatedRtxStream + "") === -1;
-            });
+        mLine.removeSSRC(previousRtxSSRC);
+
+        logger.debug(`groups before filtering for ${previousRtxSSRC}`);
+        logger.debug(mLine.dumpSSRCGroups());
+
+        mLine.removeGroupsWithSSRC(previousRtxSSRC);
     }
-    videoMLine.ssrcs.push({
+    mLine.addSSRCAttribute({
         id: rtxSsrc,
         attribute: "cname",
         value: primarySsrcCname
     });
-    videoMLine.ssrcs.push({
+    mLine.addSSRCAttribute({
         id: rtxSsrc,
         attribute: "msid",
         value: primarySsrcMsid
     });
-    videoMLine.ssrcGroups = videoMLine.ssrcGroups || [];
-    videoMLine.ssrcGroups.push({
+    mLine.addSSRCGroup({
         semantics: "FID",
         ssrcs: primarySsrc + " " + rtxSsrc
     });
@@ -163,62 +109,65 @@ export default class RtxModifier {
      * @param {string} sdpStr sdp in raw string format
      */
     modifyRtxSsrcs (sdpStr) {
-        let parsedSdp = transform.parse(sdpStr);
-        let videoMLine = 
-            parsedSdp.media.find(mLine => mLine.type === "video");
-        if (videoMLine.direction === "inactive" ||
-                videoMLine.direction === "recvonly") {
+        const sdpTransformer = new SdpTransformWrap(sdpStr);
+        const videoMLine = sdpTransformer.selectMedia("video");
+        if (!videoMLine) {
+            logger.error(`No 'video' media found in the sdp: ${sdpStr}`);
+            return sdpStr;
+        }
+        if (videoMLine.direction === "inactive"
+                || videoMLine.direction === "recvonly") {
             logger.debug("RtxModifier doing nothing, video " +
                 "m line is inactive or recvonly");
             return sdpStr;
         }
-        if (!videoMLine.ssrcs) {
+        if (videoMLine.getSSRCCount() < 1) {
           logger.debug("RtxModifier doing nothing, no video ssrcs present");
           return sdpStr;
         }
         logger.debug("Current ssrc mapping: ", this.correspondingRtxSsrcs);
-        let primaryVideoSsrcs = getPrimaryVideoSsrcs(videoMLine);
-        logger.debug("Parsed primary video ssrcs ", primaryVideoSsrcs, " " +
-            "making sure all have rtx streams");
-        primaryVideoSsrcs.forEach(ssrc => {
-            let msid = SDPUtil.getSsrcAttribute(videoMLine, ssrc, "msid");
-            let cname = SDPUtil.getSsrcAttribute(videoMLine, ssrc, "cname");
+        const primaryVideoSsrcs = videoMLine.getPrimaryVideoSSRCs();
+        logger.debug("Parsed primary video ssrcs ", primaryVideoSsrcs,
+            " making sure all have rtx streams");
+        for (const ssrc of primaryVideoSsrcs) {
+            let msid = videoMLine.getSSRCAttrValue(ssrc, "msid");
+            let cname = videoMLine.getSSRCAttrValue(ssrc, "cname");
             let correspondingRtxSsrc = this.correspondingRtxSsrcs.get(ssrc);
             if (correspondingRtxSsrc) {
-                logger.debug("Already have an associated rtx ssrc for " +
-                    " video ssrc " + ssrc + ": " + 
-                    correspondingRtxSsrc);
+                logger.debug(
+                    `Already have an associated rtx ssrc for` +
+                    `video ssrc ${ssrc}: ${correspondingRtxSsrc}`);
             } else {
-                logger.debug("No previously associated rtx ssrc for " +
-                    " video ssrc " + ssrc);
+                logger.debug(
+                    `No previously associated rtx ssrc for video ssrc ${ssrc}`);
                 // If there's one in the sdp already for it, we'll just set
                 //  that as the corresponding one
-                let previousAssociatedRtxStream = 
-                    getRtxSsrc (videoMLine, ssrc);
+                let previousAssociatedRtxStream = videoMLine.getRtxSSRC(ssrc);
                 if (previousAssociatedRtxStream) {
-                    logger.debug("Rtx stream " + previousAssociatedRtxStream + 
-                        " already existed in the sdp as an rtx stream for " +
-                        ssrc);
+                    logger.debug(
+                        `Rtx stream ${previousAssociatedRtxStream} ` +
+                        `already existed in the sdp as an rtx stream for ` +
+                        `${ssrc}`);
                     correspondingRtxSsrc = previousAssociatedRtxStream;
                 } else {
                     correspondingRtxSsrc = SDPUtil.generateSsrc();
-                    logger.debug("Generated rtx ssrc " + correspondingRtxSsrc + 
-                        " for ssrc " + ssrc);
+                    logger.debug(`Generated rtx ssrc ${correspondingRtxSsrc} ` +
+                                 `for ssrc ${ssrc}`);
                 }
-                logger.debug("Caching rtx ssrc " + correspondingRtxSsrc + 
-                    " for video ssrc " + ssrc);
+                logger.debug(`Caching rtx ssrc ${correspondingRtxSsrc} ` +
+                             `for video ssrc ${ssrc}`);
                 this.correspondingRtxSsrcs.set(ssrc, correspondingRtxSsrc);
             }
             updateAssociatedRtxStream(
-                videoMLine, 
+                videoMLine,
                 {
                     id: ssrc,
                     cname: cname,
                     msid: msid
                 },
                 correspondingRtxSsrc);
-        });
-        return transform.write(parsedSdp);
+        }
+        return sdpTransformer.toRawSDP();
     }
 
     /**
@@ -227,39 +176,36 @@ export default class RtxModifier {
      * @returns {string} sdp string with all rtx streams stripped
      */
     stripRtx (sdpStr) {
-        const parsedSdp = transform.parse(sdpStr);
-        const videoMLine = 
-            parsedSdp.media.find(mLine => mLine.type === "video");
-        if (videoMLine.direction === "inactive" ||
-                videoMLine.direction === "recvonly") {
+        const sdpTransformer = new SdpTransformWrap(sdpStr);
+        const videoMLine = sdpTransformer.selectMedia("video");
+        if (!videoMLine) {
+            logger.error(`No 'video' media found in the sdp: ${sdpStr}`);
+            return sdpStr;
+        }
+        if (videoMLine.direction === "inactive"
+                || videoMLine.direction === "recvonly") {
             logger.debug("RtxModifier doing nothing, video " +
                 "m line is inactive or recvonly");
             return sdpStr;
         }
-        if (!videoMLine.ssrcs) {
+        if (videoMLine.getSSRCCount() < 1) {
           logger.debug("RtxModifier doing nothing, no video ssrcs present");
           return sdpStr;
         }
-        if (!videoMLine.ssrcGroups) {
-          logger.debug("RtxModifier doing nothing, " + 
+        if (!videoMLine.containsAnySSRCGroups()) {
+          logger.debug("RtxModifier doing nothing, " +
               "no video ssrcGroups present");
           return sdpStr;
         }
-        const fidGroups = videoMLine.ssrcGroups
-            .filter(group => group.semantics === "FID");
+        const fidGroups = videoMLine.findGroups("FID");
         // Remove the fid groups from the mline
-        videoMLine.ssrcGroups = videoMLine.ssrcGroups
-            .filter(group => group.semantics !== "FID");
+        videoMLine.removeGroupsBySemantics("FID");
         // Get the rtx ssrcs and remove them from the mline
-        const ssrcsToRemove = [];
-        fidGroups.forEach(fidGroup => {
-            const groupSsrcs = SDPUtil.parseGroupSsrcs(fidGroup);
-            const rtxSsrc = groupSsrcs[1];
-            ssrcsToRemove.push(rtxSsrc);
-        });
-        videoMLine.ssrcs = videoMLine.ssrcs
-            .filter(line => ssrcsToRemove.indexOf(line.id) === -1);
-        
-        return transform.write(parsedSdp);
+        for (const fidGroup of fidGroups) {
+            const rtxSsrc = parseSecondarySSRC(fidGroup);
+            videoMLine.removeSSRC(rtxSsrc);
+        }
+
+        return sdpTransformer.toRawSDP();
     }
 }

--- a/modules/xmpp/SdpConsistency.js
+++ b/modules/xmpp/SdpConsistency.js
@@ -1,51 +1,11 @@
+/* global __filename */
+
 import { getLogger } from "jitsi-meet-logger";
+import { parsePrimarySSRC,
+         parseSecondarySSRC,
+         SdpTransformWrap } from './SdpTransformUtil';
+
 const logger = getLogger(__filename);
-import * as transform from 'sdp-transform';
-import * as SDPUtil from "./SDPUtil";
-
-/**
- * Begin helper functions
- */
-/**
- * Given a video mline (as parsed from transform.parse),
- *  return the single primary video ssrcs
- * @param {object} videoMLine the video MLine from which to extract the
- *  primary video ssrc
- * @returns {number} the primary video ssrc
- */
-function getPrimarySsrc (videoMLine) {
-    if (!videoMLine.ssrcs) {
-        return;
-    }
-    let numSsrcs = videoMLine.ssrcs
-        .map(ssrcInfo => ssrcInfo.id)
-        .filter((ssrc, index, array) => array.indexOf(ssrc) === index)
-        .length;
-    if (numSsrcs === 1) {
-        return videoMLine.ssrcs[0].id;
-    } else {
-        let findGroup = (mLine, groupName) => {
-            return mLine
-                .ssrcGroups
-                .filter(group => group.semantics === groupName)[0];
-        };
-        // Look for a SIM or FID group
-        if (videoMLine.ssrcGroups) {
-            let simGroup = findGroup(videoMLine, "SIM");
-            if (simGroup) {
-                return SDPUtil.parseGroupSsrcs(simGroup)[0];
-            }
-            let fidGroup = findGroup(videoMLine, "FID");
-            if (fidGroup) {
-                return SDPUtil.parseGroupSsrcs(fidGroup)[0];
-            }
-        }
-    }
-}
-
-/**
- * End helper functions
- */
 
 /**
  * Handles the work of keeping video ssrcs consistent across multiple
@@ -76,8 +36,12 @@ export default class SdpConsistency {
      *  makeVideoPrimarySsrcsConsistent
      * @param {number} primarySsrc the primarySsrc to be used
      *  in future calls to makeVideoPrimarySsrcsConsistent
+     * @throws Error if <tt>primarySsrc</tt> is not a number
      */
     setPrimarySsrc (primarySsrc) {
+        if (typeof primarySsrc !== 'number') {
+            throw new Error("Primary SSRC must be a number!");
+        }
         this.cachedPrimarySsrc = primarySsrc;
     }
 
@@ -93,61 +57,59 @@ export default class SdpConsistency {
      *  with ssrcs consistent with this class' cache
      */
     makeVideoPrimarySsrcsConsistent (sdpStr) {
-        let parsedSdp = transform.parse(sdpStr);
-        let videoMLine =
-            parsedSdp.media.find(mLine => mLine.type === "video");
+        const sdpTransformer = new SdpTransformWrap(sdpStr);
+        const videoMLine = sdpTransformer.selectMedia("video");
+        if (!videoMLine) {
+            logger.error(`No 'video' media found in the sdp: ${sdpStr}`);
+            return sdpStr;
+        }
         if (videoMLine.direction === "inactive") {
-            logger.info("Sdp-consistency doing nothing, " +
-                "video mline is inactive");
+            logger.info(
+                "Sdp-consistency doing nothing, video mline is inactive");
             return sdpStr;
         }
         if (videoMLine.direction === "recvonly") {
             // If the mline is recvonly, we'll add the primary
             //  ssrc as a recvonly ssrc
-            videoMLine.ssrcs = videoMLine.ssrcs || [];
             if (this.cachedPrimarySsrc) {
-                videoMLine.ssrcs.push({
+                videoMLine.addSSRCAttribute({
                     id: this.cachedPrimarySsrc,
                     attribute: "cname",
-                    value: "recvonly-" + this.cachedPrimarySsrc
+                    value: `recvonly-${this.cachedPrimarySsrc}`
                 });
             } else {
                 logger.error("No SSRC found for the recvonly video stream!");
             }
         } else {
-            let newPrimarySsrc = getPrimarySsrc(videoMLine);
+            let newPrimarySsrc = videoMLine.getPrimaryVideoSsrc();
             if (!newPrimarySsrc) {
                 logger.info("Sdp-consistency couldn't parse new primary ssrc");
                 return sdpStr;
             }
             if (!this.cachedPrimarySsrc) {
                 this.cachedPrimarySsrc = newPrimarySsrc;
-                logger.info("Sdp-consistency caching primary ssrc " + 
-                    this.cachedPrimarySsrc);
+                logger.info(
+                    "Sdp-consistency caching primary ssrc "
+                    + this.cachedPrimarySsrc);
             } else {
-                logger.info("Sdp-consistency replacing new ssrc " + 
-                    newPrimarySsrc + " with cached " + this.cachedPrimarySsrc);
-                videoMLine.ssrcs.forEach(ssrcInfo => {
-                    if (ssrcInfo.id === newPrimarySsrc) {
-                        ssrcInfo.id = this.cachedPrimarySsrc;
-                    }
-                });
-                if (videoMLine.ssrcGroups) {
-                    videoMLine.ssrcGroups.forEach(group => {
-                        if (group.semantics === "FID") {
-                            let fidGroupSsrcs = SDPUtil.parseGroupSsrcs(group);
-                            let primarySsrc = fidGroupSsrcs[0];
-                            let rtxSsrc = fidGroupSsrcs[1];
-                            if (primarySsrc === newPrimarySsrc) {
-                                group.ssrcs = 
-                                    this.cachedPrimarySsrc + " " + 
-                                        rtxSsrc;
-                            }
+                logger.info(
+                    `Sdp-consistency replacing new ssrc ` +
+                    `${newPrimarySsrc} with cached ${this.cachedPrimarySsrc}`);
+                videoMLine.replaceSSRC(
+                    newPrimarySsrc, this.cachedPrimarySsrc);
+                for (const group of videoMLine.ssrcGroups) {
+                    if (group.semantics === "FID") {
+                        let primarySsrc = parsePrimarySSRC(group);
+                        let rtxSsrc = parseSecondarySSRC(group);
+                        if (primarySsrc === newPrimarySsrc) {
+                            group.ssrcs =
+                                this.cachedPrimarySsrc + " " +
+                                    rtxSsrc;
                         }
-                    });
+                    }
                 }
             }
         }
-        return transform.write(parsedSdp);
+        return sdpTransformer.toRawSDP();
     }
 }

--- a/modules/xmpp/SdpTransformUtil.js
+++ b/modules/xmpp/SdpTransformUtil.js
@@ -1,0 +1,397 @@
+import * as transform from 'sdp-transform';
+
+/**
+ * Parses the primary SSRC of given SSRC group.
+ * @param {object} group the SSRC group object as defined by the 'sdp-transform'
+ * @return {Number} the primary SSRC number
+ */
+export function parsePrimarySSRC(group) {
+    return parseInt(group.ssrcs.split(" ")[0]);
+}
+
+/**
+ * Parses the secondary SSRC of given SSRC group.
+ * @param {object} group the SSRC group object as defined by the 'sdp-transform'
+ * @return {Number} the secondary SSRC number
+ */
+export function parseSecondarySSRC(group) {
+    return parseInt(group.ssrcs.split(" ")[1]);
+}
+
+/**
+ * Tells how many distinct SSRCs are contained in given media line.
+ * @param {Object} mLine the media line object as defined by 'sdp-transform' lib
+ * @return {number}
+ */
+function _getSSRCCount(mLine) {
+    if (!mLine.ssrcs) {
+        return 0;
+    } else {
+        return mLine.ssrcs
+            .map(ssrcInfo => ssrcInfo.id)
+            .filter((ssrc, index, array) => array.indexOf(ssrc) === index)
+            .length;
+    }
+}
+
+/**
+ * Utility class for SDP manipulation using the 'sdp-transform' library.
+ *
+ * Typical use usage scenario:
+ *
+ * const transformer = new SdpTransformWrap(rawSdp);
+ * const videoMLine = transformer.selectMedia('video);
+ * if (videoMLine) {
+ *     videoMLiner.addSSRCAttribute({
+ *         id: 2342343,
+ *         attribute: "cname",
+ *         value: "someCname"
+ *     });
+ *     rawSdp = transformer.toRawSdp();
+ * }
+ */
+export class SdpTransformWrap {
+
+    /**
+     * Creates new instance and parses the raw SDP into objects using
+     * 'sdp-transform' lib.
+     * @param {string} rawSDP the SDP in raw text format.
+     */
+    constructor(rawSDP) {
+        this.parsedSDP = transform.parse(rawSDP);
+    }
+
+    /**
+     * Selects the first media SDP of given name.
+     * @param {string} mediaType the name of the media e.g. 'audio', 'video',
+     * 'data'.
+     * @return {MLineWrap|null} return {@link MLineWrap} instance for the media
+     * line or <tt>null</tt> if not found. The object returned references
+     * the underlying SDP state held by this <tt>SdpTransformWrap</tt> instance
+     * (it's not a copy).
+     */
+    selectMedia(mediaType) {
+        const selectedMLine
+            = this.parsedSDP.media.find(mLine => mLine.type === mediaType);
+        return selectedMLine ? new MLineWrap(selectedMLine) : null;
+    }
+
+    /**
+     * Converts the currently stored SDP state in this instance to raw text SDP
+     * format.
+     * @return {string}
+     */
+    toRawSDP() {
+        return transform.write(this.parsedSDP);
+    }
+}
+
+/**
+ * A wrapper around 'sdp-transform' media description object which provides
+ * utility methods for common SDP/SSRC related operations.
+ */
+class MLineWrap {
+
+    /**
+     * Creates new <tt>MLineWrap</t>>
+     * @param {Object} mLine the media line object as defined by 'sdp-transform'
+     * lib.
+     */
+    constructor(mLine) {
+        if (!mLine) {
+            throw new Error("mLine is undefined");
+        }
+
+        this.mLine = mLine;
+    }
+
+    get _ssrcs () {
+        if (!this.mLine.ssrcs) {
+            this.mLine.ssrcs = [];
+        }
+        return this.mLine.ssrcs;
+    }
+
+    /**
+     * Returns the direction of the underlying media description.
+     * @return {string} the media direction name as defined in the SDP.
+     */
+    get direction() {
+        return this.mLine.direction;
+    }
+
+    /**
+     * Modifies the direction of the underlying media description.
+     * @param {string} direction the new direction to be set
+     */
+    set direction (direction) {
+        this.mLine.direction = direction;
+    }
+
+    /**
+     * Exposes the SSRC group array of the underlying media description object.
+     * @return {Array.<Object>}
+     */
+    get ssrcGroups () {
+        if (!this.mLine.ssrcGroups) {
+            this.mLine.ssrcGroups = [];
+        }
+        return this.mLine.ssrcGroups;
+    }
+
+    /**
+     * Modifies the SSRC groups array of the underlying media description
+     * object.
+     * @param {Array.<Object>} ssrcGroups
+     */
+    set ssrcGroups (ssrcGroups) {
+        this.mLine.ssrcGroups = ssrcGroups;
+    }
+
+    /**
+     * Checks whether the underlying media description contains given SSRC
+     * number.
+     * @param {string} ssrcNumber
+     * @return {boolean} <tt>true</tt> if given SSRC has been found or
+     * <tt>false</tt> otherwise.
+     */
+    containsSSRC(ssrcNumber) {
+        return !!this._ssrcs.find(
+            ssrcObj => { return ssrcObj.id == ssrcNumber; });
+    }
+
+    /**
+     * Obtains value from SSRC attribute.
+     * @param {number} ssrcNumber the SSRC number for which attribute is to be
+     * found
+     * @param {string} attrName the name of the SSRC attribute to be found.
+     * @return {string|undefined} the value of SSRC attribute or
+     * <tt>undefined</tt> if no such attribute exists.
+     */
+    getSSRCAttrValue(ssrcNumber, attrName) {
+        const attribute = this._ssrcs.find(
+            ssrcObj => ssrcObj.id == ssrcNumber
+            && ssrcObj.attribute === attrName);
+        return attribute && attribute.value;
+    }
+
+    /**
+     * Removes all attributes for given SSRC number.
+     * @param {number} ssrcNum the SSRC number for which all attributes will be
+     * removed.
+     */
+    removeSSRC(ssrcNum) {
+        if (!this.mLine.ssrcs || !this.mLine.ssrcs.length) {
+            return;
+        }
+
+        this.mLine.ssrcs
+            = this.mLine.ssrcs.filter(ssrcObj => ssrcObj.id !== ssrcNum);
+    }
+
+    /**
+     * Adds SSRC attribute
+     * @param {object} ssrcObj the SSRC attribute object as defined in
+     * the 'sdp-transform' lib.
+     */
+    addSSRCAttribute(ssrcObj) {
+        this._ssrcs.push(ssrcObj);
+    }
+
+    /**
+     * Finds a SSRC group matching both semantics and SSRCs in order.
+     * @param {string} semantics the name of the semantics
+     * @param {string} [ssrcs] group SSRCs as a string (like it's defined in
+     * SSRC group object of the 'sdp-transform' lib) e.g. "1232546 342344 25434"
+     * @return {object|undefined} the SSRC group object or <tt>undefined</tt> if
+     * not found.
+     */
+    findGroup(semantics, ssrcs) {
+        return this.ssrcGroups.find(
+            group => group.semantics === semantics
+                && !ssrcs || ssrcs === group.ssrcs);
+    }
+
+    /**
+     * Finds all groups matching given semantic's name.
+     * @param {string} semantics the name of the semantics
+     * @return {Array.<object>} an array of SSRC group objects as defined by
+     * the 'sdp-transform' lib.
+     */
+    findGroups(semantics) {
+        return this.ssrcGroups.filter(
+            group => group.semantics === semantics);
+    }
+
+    /**
+     * Finds all groups matching given semantic's name and group's primary SSRC.
+     * @param {string} semantics the name of the semantics
+     * @param {number} primarySSRC the primary SSRC number to be matched
+     * @return {Object} SSRC group object as defined by the 'sdp-transform' lib.
+     */
+    findGroupByPrimarySSRC(semantics, primarySSRC) {
+        return this.ssrcGroups.find(
+            group => group.semantics === semantics
+                && parsePrimarySSRC(group) === primarySSRC);
+    }
+
+    /**
+     * Gets the SSRC count for the underlying media description.
+     * @return {number}
+     */
+    getSSRCCount() {
+        return _getSSRCCount(this.mLine);
+    }
+
+    /**
+     * Checks whether the underlying media description contains any SSRC groups.
+     * @return {boolean} <tt>true</tt> if there are any SSRC groups or
+     * <tt>false</tt> otherwise.
+     */
+    containsAnySSRCGroups() {
+        return !!this.mLine.ssrcGroups;
+    }
+
+    /**
+     * Finds the primary video SSRC.
+     * @returns {number|undefined} the primary video ssrc
+     * @throws Error if the underlying media description is not a video
+     */
+    getPrimaryVideoSsrc () {
+        const mediaType = this.mLine.type;
+
+        if (mediaType !== 'video') {
+            throw new Error(
+                `getPrimarySsrc doesn't work with '${mediaType}'`);
+        }
+
+        const numSsrcs = _getSSRCCount(this.mLine);
+        if (numSsrcs === 1) {
+            // Not using _ssrcs on purpose here
+            return this.mLine.ssrcs[0].id;
+        } else {
+            // Look for a SIM or FID group
+            if (this.mLine.ssrcGroups) {
+                const simGroup = this.findGroup("SIM");
+                if (simGroup) {
+                    return parsePrimarySSRC(simGroup);
+                }
+                const fidGroup = this.findGroup("FID");
+                if (fidGroup) {
+                    return parsePrimarySSRC(fidGroup);
+                }
+            }
+        }
+    }
+
+    /**
+     * Obtains RTX SSRC from the underlying video description (the
+     * secondary SSRC of the first "FID" group found)
+     * @param {number} primarySsrc the video ssrc for which to find the
+     * corresponding rtx ssrc
+     * @returns {number|undefined} the rtx ssrc (or undefined if there isn't
+     * one)
+     */
+    getRtxSSRC (primarySsrc) {
+        const fidGroup = this.findGroupByPrimarySSRC("FID", primarySsrc);
+        return fidGroup && parseSecondarySSRC(fidGroup);
+    }
+
+    /**
+     * Obtains all SSRCs contained in the underlying media description.
+     * @return {Array.<number>} an array with all SSRC as numbers.
+     */
+    getSSRCs () {
+        return this._ssrcs
+            .map(ssrcInfo => ssrcInfo.id)
+            .filter((ssrc, index, array) => array.indexOf(ssrc) === index);
+    }
+
+    /**
+     * Obtains primary video SSRCs.
+     * @return {Array.<number>} an array of all primary video SSRCs as numbers.
+     * @throws Error if the wrapped media description is not a video.
+     */
+    getPrimaryVideoSSRCs () {
+        const mediaType = this.mLine.type;
+
+        if (mediaType !== 'video') {
+            throw new Error(
+                `getPrimaryVideoSSRCs doesn't work with ${mediaType}`);
+        }
+
+        const videoSSRCs = this.getSSRCs();
+
+        for (const ssrcGroupInfo of this.ssrcGroups) {
+            // Right now, FID groups are the only ones we parse to
+            // disqualify streams.  If/when others arise we'll
+            // need to add support for them here
+            if (ssrcGroupInfo.semantics === "FID") {
+                // secondary FID streams should be filtered out
+                const secondarySsrc = parseSecondarySSRC(ssrcGroupInfo);
+                videoSSRCs.splice(
+                    videoSSRCs.indexOf(secondarySsrc), 1);
+            }
+        }
+        return videoSSRCs;
+    }
+
+    /**
+     * Dumps all SSRC groups of this media description to JSON.
+     */
+    dumpSSRCGroups() {
+        return JSON.stringify(this.mLine.ssrcGroups);
+    }
+
+    /**
+     * Removes all SSRC groups which contain given SSRC number at any position.
+     * @param {number} ssrc the SSRC for which all matching groups are to be
+     * removed.
+     */
+    removeGroupsWithSSRC(ssrc) {
+        if (!this.mLine.ssrcGroups) {
+            return;
+        }
+
+        this.mLine.ssrcGroups = this.mLine.ssrcGroups
+            .filter(groupInfo => groupInfo.ssrcs.indexOf(ssrc + "") === -1);
+    }
+
+    /**
+     * Removes groups that match given semantics.
+     * @param {string} semantics e.g. "SIM" or "FID"
+     */
+    removeGroupsBySemantics(semantics) {
+        if (!this.mLine.ssrcGroups) {
+            return;
+        }
+
+        this.mLine.ssrcGroups
+            = this.mLine.ssrcGroups
+                  .filter(groupInfo => groupInfo.semantics !== semantics);
+    }
+
+    /**
+     * Replaces SSRC (does not affect SSRC groups, but only attributes).
+     * @param {number} oldSSRC the old SSRC number
+     * @param {number} newSSRC the new SSRC number
+     */
+    replaceSSRC(oldSSRC, newSSRC) {
+        if (this.mLine.ssrcs) {
+            this.mLine.ssrcs.forEach(ssrcInfo => {
+                if (ssrcInfo.id === oldSSRC) {
+                    ssrcInfo.id = newSSRC;
+                }
+            });
+        }
+    }
+
+    /**
+     * Adds given SSRC group to this media description.
+     * @param {object} group the SSRC group object as defined by
+     * the 'sdp-transform' lib.
+     */
+    addSSRCGroup(group) {
+        this.ssrcGroups.push(group);
+    }
+}


### PR DESCRIPTION
* ref(TraceablePeerConnection): rename var to what it is

* ref(ssrc info): get rid of 'ssrc' and 'group' roots

Removes 'ssrc' and 'group' root Objects from "ssrc info" structure.
Also removed redundant 'primarySSRC' from the group.
Do not split and join back and forth the SSRCs, but store them as
numbers.

* feat: add SdpTransformUtil

* ref(rtxModifier): rename "previousAssociatedRtxStream"

* ref(RtxModifier): use for .. of

* fix(SdpConsistency): organize imports

* fix(RtxModifier): organize imports

* ref(JitsiLocalTrack): simplify the expression

* extract MLineWrap (ongoing)

* ref(TPC.extractSSRCMap): some ES6 cleanup

* ref(RtxModifier): use template strings

* doc(SdpTransformUtil): update and fill missing

* ref(SdpTransformUtil): const, template strings

* style(TPC): object formatting

* ref(JitsiLocalTrack): simplify expression + syntax

* ref(TPC): more "extractSSRCMap" improvements

* ref(RtxModifier): const all the things

* ref(SdpConsistency): template strings

* ref(SdpTransformUtil): syntax + other

* doc(SdpConsistency): add throws description

* fix(TPC): broken "extractSSCMap"

* fix(JitsiConference): adopt to Map

* ref(SdpTransformUtil): remove forEachSSRCGroup and static methods