### PR TITLE
P2P ver2 (#413)

### DIFF
--- a/JitsiConferenceEventManager.js
+++ b/JitsiConferenceEventManager.js
@@ -29,6 +29,12 @@ function JitsiConferenceEventManager(conference) {
             conference.statistics.sendMuteEvent(track.isMuted(),
                 track.getType());
         });
+    conference.on(
+        JitsiConferenceEvents.CONNECTION_INTERRUPTED,
+        Statistics.sendEventToAll.bind(Statistics, 'connection.interrupted'));
+    conference.on(
+        JitsiConferenceEvents.CONNECTION_RESTORED,
+        Statistics.sendEventToAll.bind(Statistics, 'connection.restored'));
 }
 
 /**
@@ -111,11 +117,15 @@ JitsiConferenceEventManager.prototype.setupChatRoomListeners = function() {
     this.chatRoomForwarder = new EventEmitterForwarder(chatRoom,
         this.conference.eventEmitter);
 
-    chatRoom.addListener(XMPPEvents.ICE_RESTARTING, () => {
-        // All data channels have to be closed, before ICE restart
-        // otherwise Chrome will not trigger "opened" event for the channel
-        // established with the new bridge
-        conference.rtc.closeAllDataChannels();
+    chatRoom.addListener(XMPPEvents.ICE_RESTARTING, jingleSession => {
+        if (!jingleSession.isP2P) {
+            // All data channels have to be closed, before ICE restart
+            // otherwise Chrome will not trigger "opened" event for the channel
+            // established with the new bridge
+            conference.rtc.closeAllDataChannels();
+        }
+
+        // else: there are no DataChannels in P2P session (at least for now)
     });
 
     chatRoom.addListener(XMPPEvents.AUDIO_MUTED_BY_FOCUS,
@@ -140,7 +150,7 @@ JitsiConferenceEventManager.prototype.setupChatRoomListeners = function() {
     // send some analytics events
     chatRoom.addListener(XMPPEvents.MUC_JOINED,
         () => {
-            this.conference.connectionIsInterrupted = false;
+            this.conference.isJvbConnectionInterrupted = false;
 
             Object.keys(chatRoom.connectionTimes).forEach(key => {
                 const value = chatRoom.connectionTimes[key];
@@ -194,16 +204,16 @@ JitsiConferenceEventManager.prototype.setupChatRoomListeners = function() {
 
     chatRoom.addListener(XMPPEvents.JINGLE_FATAL_ERROR,
         (session, error) => {
-            conference.eventEmitter.emit(
-                JitsiConferenceEvents.CONFERENCE_FAILED,
-                JitsiConferenceErrors.JINGLE_FATAL_ERROR, error);
+            if (!session.isP2P) {
+                conference.eventEmitter.emit(
+                    JitsiConferenceEvents.CONFERENCE_FAILED,
+                    JitsiConferenceErrors.JINGLE_FATAL_ERROR, error);
+            }
         });
 
     chatRoom.addListener(XMPPEvents.CONNECTION_ICE_FAILED,
-        () => {
-            chatRoom.eventEmitter.emit(
-                XMPPEvents.CONFERENCE_SETUP_FAILED,
-                new Error('ICE fail'));
+        jingleSession => {
+            conference._onIceConnectionFailed(jingleSession);
         });
 
     this.chatRoomForwarder.forward(XMPPEvents.MUC_DESTROYED,
@@ -230,14 +240,10 @@ JitsiConferenceEventManager.prototype.setupChatRoomListeners = function() {
         = reason => Statistics.sendEventToAll(`conference.error.${reason}`);
 
     chatRoom.addListener(XMPPEvents.SESSION_ACCEPT_TIMEOUT,
-        eventLogHandler.bind(null, 'sessionAcceptTimeout'));
-
-    this.chatRoomForwarder.forward(XMPPEvents.CONNECTION_INTERRUPTED,
-        JitsiConferenceEvents.CONNECTION_INTERRUPTED);
-    chatRoom.addListener(XMPPEvents.CONNECTION_INTERRUPTED,
-        () => {
-            Statistics.sendEventToAll('connection.interrupted');
-            this.conference.connectionIsInterrupted = true;
+        jingleSession => {
+            eventLogHandler(
+                jingleSession.isP2P
+                    ? 'p2pSessionAcceptTimeout' : 'sessionAcceptTimeout');
         });
 
     this.chatRoomForwarder.forward(XMPPEvents.RECORDER_STATE_CHANGED,
@@ -246,17 +252,16 @@ JitsiConferenceEventManager.prototype.setupChatRoomListeners = function() {
     this.chatRoomForwarder.forward(XMPPEvents.PHONE_NUMBER_CHANGED,
         JitsiConferenceEvents.PHONE_NUMBER_CHANGED);
 
-    this.chatRoomForwarder.forward(XMPPEvents.CONNECTION_RESTORED,
-        JitsiConferenceEvents.CONNECTION_RESTORED);
-    chatRoom.addListener(XMPPEvents.CONNECTION_RESTORED,
-        () => {
-            Statistics.sendEventToAll('connection.restored');
-            this.conference.connectionIsInterrupted = false;
+    chatRoom.addListener(
+        XMPPEvents.CONFERENCE_SETUP_FAILED,
+        (jingleSession, error) => {
+            if (!jingleSession.isP2P) {
+                conference.eventEmitter.emit(
+                    JitsiConferenceEvents.CONFERENCE_FAILED,
+                    JitsiConferenceErrors.SETUP_FAILED,
+                    error);
+            }
         });
-
-    this.chatRoomForwarder.forward(XMPPEvents.CONFERENCE_SETUP_FAILED,
-        JitsiConferenceEvents.CONFERENCE_FAILED,
-        JitsiConferenceErrors.SETUP_FAILED);
 
     chatRoom.setParticipantPropertyListener((node, from) => {
         const participant = conference.getParticipantById(from);
@@ -294,8 +299,7 @@ JitsiConferenceEventManager.prototype.setupChatRoomListeners = function() {
         conference.onDisplayNameChanged.bind(conference));
 
     chatRoom.addListener(XMPPEvents.LOCAL_ROLE_CHANGED, role => {
-        conference.eventEmitter.emit(JitsiConferenceEvents.USER_ROLE_CHANGED,
-            conference.myUserId(), role);
+        conference.onLocalRoleChanged(role);
 
         // log all events for the recorder operated by the moderator
         if (conference.statistics && conference.isModerator()) {
@@ -351,19 +355,6 @@ JitsiConferenceEventManager.prototype.setupChatRoomListeners = function() {
                 JitsiConferenceEvents.USER_STATUS_CHANGED, id, status);
         });
 
-    conference.room.addListener(XMPPEvents.LOCAL_UFRAG_CHANGED,
-        ufrag => {
-            Statistics.sendLog(
-                JSON.stringify({ id: 'local_ufrag',
-                    value: ufrag }));
-        });
-    conference.room.addListener(XMPPEvents.REMOTE_UFRAG_CHANGED,
-        ufrag => {
-            Statistics.sendLog(
-                JSON.stringify({ id: 'remote_ufrag',
-                    value: ufrag }));
-        });
-
     chatRoom.addPresenceListener('startmuted', (data, from) => {
         let isModerator = false;
 
@@ -402,20 +393,6 @@ JitsiConferenceEventManager.prototype.setupChatRoomListeners = function() {
                 conference.startMutedPolicy
             );
         }
-    });
-
-    chatRoom.addPresenceListener('videomuted', (values, from) => {
-        conference.rtc.handleRemoteTrackMute(MediaType.VIDEO,
-            values.value === 'true', from);
-    });
-
-    chatRoom.addPresenceListener('audiomuted', (values, from) => {
-        conference.rtc.handleRemoteTrackMute(MediaType.AUDIO,
-            values.value === 'true', from);
-    });
-
-    chatRoom.addPresenceListener('videoType', (data, from) => {
-        conference.rtc.handleRemoteTrackVideoTypeChanged(data.value, from);
     });
 
     chatRoom.addPresenceListener('devices', (data, from) => {
@@ -467,7 +444,7 @@ JitsiConferenceEventManager.prototype.setupChatRoomListeners = function() {
     if (conference.statistics) {
         // FIXME ICE related events should end up in RTCEvents eventually
         chatRoom.addListener(XMPPEvents.CONNECTION_ICE_FAILED,
-            pc => {
+            (session, pc) => {
                 conference.statistics.sendIceConnectionFailedEvent(pc);
             });
         chatRoom.addListener(XMPPEvents.ADD_ICE_CANDIDATE_FAILED,
@@ -543,6 +520,27 @@ JitsiConferenceEventManager.prototype.setupRTCListeners = function() {
             }
         });
 
+    rtc.addListener(RTCEvents.LOCAL_UFRAG_CHANGED,
+        (tpc, ufrag) => {
+            if (!tpc.isP2P) {
+                Statistics.sendLog(
+                    JSON.stringify({
+                        id: 'local_ufrag',
+                        value: ufrag
+                    }));
+            }
+        });
+    rtc.addListener(RTCEvents.REMOTE_UFRAG_CHANGED,
+        (tpc, ufrag) => {
+            if (!tpc.isP2P) {
+                Statistics.sendLog(
+                    JSON.stringify({
+                        id: 'remote_ufrag',
+                        value: ufrag
+                    }));
+            }
+        });
+
     if (conference.statistics) {
         rtc.addListener(RTCEvents.CREATE_ANSWER_FAILED,
             (e, pc) => {
@@ -588,6 +586,12 @@ JitsiConferenceEventManager.prototype.setupXMPPListeners = function() {
         XMPPEvents.CALL_INCOMING,
         conference.onIncomingCall.bind(conference));
     conference.xmpp.addListener(
+        XMPPEvents.CALL_ACCEPTED,
+        conference.onCallAccepted.bind(conference));
+    conference.xmpp.addListener(
+        XMPPEvents.TRANSPORT_INFO,
+        conference.onTransportInfo.bind(conference));
+    conference.xmpp.addListener(
         XMPPEvents.CALL_ENDED,
         conference.onCallEnded.bind(conference));
 
@@ -624,13 +628,7 @@ JitsiConferenceEventManager.prototype.setupStatisticsListeners = function() {
     }
 
     conference.statistics.addAudioLevelListener((ssrc, level) => {
-        const resource = conference.rtc.getResourceBySSRC(ssrc);
-
-        if (!resource) {
-            return;
-        }
-
-        conference.rtc.setAudioLevel(resource, level);
+        conference.rtc.setAudioLevel(ssrc, level);
     });
 
     // Forward the "before stats disposed" event
@@ -647,15 +645,15 @@ JitsiConferenceEventManager.prototype.setupStatisticsListeners = function() {
             JitsiConferenceEvents.CONNECTION_STATS, stats);
     });
 
-    conference.statistics.addByteSentStatsListener(stats => {
+    conference.statistics.addByteSentStatsListener((tpc, stats) => {
         conference.getLocalTracks(MediaType.AUDIO).forEach(track => {
-            const ssrc = track.getSSRC();
+            const ssrc = tpc.getLocalSSRC(track);
 
             if (!ssrc || !stats.hasOwnProperty(ssrc)) {
                 return;
             }
 
-            track._setByteSent(stats[ssrc]);
+            track._setByteSent(tpc, stats[ssrc]);
         });
     });
 };

--- a/JitsiConferenceEvents.js
+++ b/JitsiConferenceEvents.js
@@ -133,6 +133,13 @@ export const PARTICIPANT_PROPERTY_CHANGED
     = 'conference.participant_property_changed';
 
 /**
+ * Indicates that the conference has switched between JVB and P2P connections.
+ * The first argument of this event is a <tt>boolean</tt> which when set to
+ * <tt>true</tt> means that the conference is running on the P2P connection.
+ */
+export const P2P_STATUS = 'conference.p2pStatus';
+
+/**
  * Indicates that phone number changed.
  */
 export const PHONE_NUMBER_CHANGED = 'conference.phoneNumberChanged';

--- a/JitsiConnection.js
+++ b/JitsiConnection.js
@@ -1,8 +1,7 @@
-const JitsiConference = require('./JitsiConference');
-
+import JitsiConference from './JitsiConference';
 import * as JitsiConnectionEvents from './JitsiConnectionEvents';
+import Statistics from './modules/statistics/statistics';
 import XMPP from './modules/xmpp/xmpp';
-const Statistics = require('./modules/statistics/statistics');
 
 /**
  * Creates new connection object for the Jitsi Meet server side video
@@ -90,9 +89,11 @@ JitsiConnection.prototype.setToken = function(token) {
  * @returns {JitsiConference} returns the new conference object.
  */
 JitsiConnection.prototype.initJitsiConference = function(name, options) {
-    return new JitsiConference({ name,
+    return new JitsiConference({
+        name,
         config: options,
-        connection: this });
+        connection: this
+    });
 };
 
 /**

--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -20,6 +20,7 @@ const logger = getLogger(__filename);
 /**
  * Represents a single media track(either audio or video).
  * One <tt>JitsiLocalTrack</tt> corresponds to one WebRTC MediaStreamTrack.
+ * @param {number} rtcId the ID assigned by the RTC module
  * @param stream WebRTC MediaStream, parent of the track
  * @param track underlying WebRTC MediaStreamTrack for new JitsiRemoteTrack
  * @param mediaType the MediaType of the JitsiRemoteTrack
@@ -30,6 +31,7 @@ const logger = getLogger(__filename);
  * @constructor
  */
 function JitsiLocalTrack(
+        rtcId,
         stream,
         track,
         mediaType,
@@ -37,6 +39,12 @@ function JitsiLocalTrack(
         resolution,
         deviceId,
         facingMode) {
+
+    /**
+     * The ID assigned by the RTC module on instance creation.
+     * @type {number}
+     */
+    this.rtcId = rtcId;
     JitsiTrack.call(
         this,
         null /* RTC */,
@@ -49,8 +57,7 @@ function JitsiLocalTrack(
             this.dontFireRemoveEvent = false;
         } /* inactiveHandler */,
         mediaType,
-        videoType,
-        null /* ssrc */);
+        videoType);
     this.dontFireRemoveEvent = false;
     this.resolution = resolution;
 
@@ -62,8 +69,15 @@ function JitsiLocalTrack(
 
     this.deviceId = deviceId;
     this.startMuted = false;
-    this.initialMSID = this.getMSID();
+    this.storedMSID = this.getMSID();
     this.inMuteOrUnmuteProgress = false;
+
+    /**
+     * An array which stores the peer connection to which this local track is
+     * currently attached to. See {@link TraceablePeerConnection.attachTrack}.
+     * @type {Set<TraceablePeerConnection>}
+     */
+    this.peerConnections = new Set();
 
     /**
      * The facing mode of the camera from which this JitsiLocalTrack instance
@@ -143,6 +157,34 @@ function JitsiLocalTrack(
 
 JitsiLocalTrack.prototype = Object.create(JitsiTrack.prototype);
 JitsiLocalTrack.prototype.constructor = JitsiLocalTrack;
+
+JitsiLocalTrack.prototype._addPeerConnection = function(tpc) {
+    if (this._isAttachedToPC(tpc)) {
+        logger.error(`${tpc} has been associated with ${this} already !`);
+    } else {
+        this.peerConnections.add(tpc);
+    }
+};
+
+JitsiLocalTrack.prototype._removePeerConnection = function(tpc) {
+    if (this._isAttachedToPC(tpc)) {
+        this.peerConnections.delete(tpc);
+    } else {
+        logger.error(`${tpc} is not associated with ${this}`);
+    }
+};
+
+/**
+ * Checks whether or not this instance is attached to given
+ * <tt>TraceablePeerConnection</tt>. See
+ * {@link TraceablePeerConnection.attachTrack} for more info.
+ * @param {TraceablePeerConnection.attachTrack} tpc
+ * @return {boolean} <tt>true</tt> if this tracks is currently attached to given
+ * peer connection or <tt>false</tt> otherwise.
+ */
+JitsiLocalTrack.prototype._isAttachedToPC = function(tpc) {
+    return this.peerConnections.has(tpc);
+};
 
 /**
  * Returns if associated MediaStreamTrack is in the 'ended' state
@@ -238,6 +280,23 @@ JitsiLocalTrack.prototype._setRealDeviceIdFromDeviceList = function(devices) {
 };
 
 /**
+ * Sets the stream property of JitsiLocalTrack object and sets all stored
+ * handlers to it.
+ * @param {MediaStream} stream the new stream.
+ */
+JitsiLocalTrack.prototype._setStream = function(stream) {
+    JitsiTrack.prototype._setStream.call(this, stream);
+
+    // Store the MSID for video mute/unmute purposes
+    if (stream) {
+        this.storedMSID = this.getMSID();
+        logger.debug(`Setting new MSID: ${this.storedMSID} on ${this}`);
+    } else {
+        logger.debug(`Setting 'null' stream on ${this}`);
+    }
+};
+
+/**
  * Mutes the track. Will reject the Promise if there is mute/unmute operation
  * in progress.
  * @returns {Promise}
@@ -300,22 +359,30 @@ JitsiLocalTrack.prototype._setMute = function(mute) {
     // Local track can be used out of conference, so we need to handle that
     // case and mark that track should start muted or not when added to
     // conference.
+    // Pawel: track's muted status should be taken into account when track is
+    // being added to the conference/JingleSessionPC/TraceablePeerConnection.
+    // There's no need to add such fields. It is logical that when muted track
+    // is being added to a conference it "starts muted"...
     if (!this.conference || !this.conference.room) {
         this.startMuted = mute;
     }
 
     this.dontFireRemoveEvent = false;
 
-    // FIXME FF does not support 'removeStream' method used to mute
+    // A function that will print info about muted status transition
+    const logMuteInfo = () => logger.info(`Mute ${this}: ${mute}`);
+
     if (this.isAudioTrack()
         || this.videoType === VideoType.DESKTOP
-        || RTCBrowserType.isFirefox()) {
+        || !RTCBrowserType.doesVideoMuteByStreamRemove()) {
+        logMuteInfo();
         if (this.track) {
             this.track.enabled = !mute;
         }
     } else if (mute) {
         this.dontFireRemoveEvent = true;
         promise = new Promise((resolve, reject) => {
+            logMuteInfo();
             this._removeStreamFromConferenceAsMute(() => {
                 // FIXME: Maybe here we should set the SRC for the containers
                 // to something
@@ -327,6 +394,8 @@ JitsiLocalTrack.prototype._setMute = function(mute) {
             });
         });
     } else {
+        logMuteInfo();
+
         // This path is only for camera.
         const streamOptions = {
             cameraDeviceId: this.getDeviceId(),
@@ -352,7 +421,7 @@ JitsiLocalTrack.prototype._setMute = function(mute) {
                     // unmute, but let's not crash here
                     if (self.videoType !== streamInfo.videoType) {
                         logger.warn(
-                            'Video type has changed after unmute!',
+                            `${this}: video type has changed after unmute!`,
                             self.videoType, streamInfo.videoType);
                         self.videoType = streamInfo.videoType;
                     }
@@ -387,18 +456,18 @@ JitsiLocalTrack.prototype._addStreamToConferenceAsUnmute = function() {
         return Promise.resolve();
     }
 
+    // FIXME it would be good to not included conference as part of this process
+    // Only TraceablePeerConnections to which the track is attached should care
+    // about this action. The TPCs to which the track is not attached can sync
+    // up when track is re-attached.
+    // A problem with that is that the "modify sources" queue is part of
+    // the JingleSessionPC and it would be excluded from the process. One
+    // solution would be to extract class between TPC and JingleSessionPC which
+    // would contain the queue and would notify the signaling layer when local
+    // SSRCs are changed. This would help to separate XMPP from the RTC module.
     return new Promise((resolve, reject) => {
-        this.conference._addLocalStream(
-            this.stream,
-            resolve,
-            error => reject(new Error(error)),
-            {
-                mtype: this.type,
-                type: 'unmute',
-                ssrcs: this.ssrc && this.ssrc.ssrcs,
-                groups: this.ssrc && this.ssrc.groups,
-                msid: this.getMSID()
-            });
+        this.conference._addLocalTrackAsUnmute(this)
+            .then(resolve, error => reject(new Error(error)));
     });
 };
 
@@ -415,17 +484,9 @@ JitsiLocalTrack.prototype._removeStreamFromConferenceAsMute
 
         return;
     }
-
-    this.conference.removeLocalStream(
-        this.stream,
+    this.conference._removeLocalTrackAsMute(this).then(
         successCallback,
-        error => errorCallback(new Error(error)),
-        {
-            mtype: this.type,
-            type: 'mute',
-            ssrcs: this.ssrc && this.ssrc.ssrcs,
-            groups: this.ssrc && this.ssrc.groups
-        });
+        error => errorCallback(new Error(error)));
 };
 
 /**
@@ -503,15 +564,6 @@ JitsiLocalTrack.prototype.isMuted = function() {
 };
 
 /**
- * Updates the SSRC associated with the MediaStream in JitsiLocalTrack object.
- * @ssrc the new ssrc
- */
-JitsiLocalTrack.prototype._setSSRC = function(ssrc) {
-    this.ssrc = ssrc;
-};
-
-
-/**
  * Sets the JitsiConference object associated with the track. This is temp
  * solution.
  * @param conference the JitsiConference object
@@ -526,24 +578,6 @@ JitsiLocalTrack.prototype._setConference = function(conference) {
     for (let i = 0; i < this.containers.length; i++) {
         this._maybeFireTrackAttached(this.containers[i]);
     }
-};
-
-/**
- * Gets the SSRC of this local track if it's available already or <tt>null</tt>
- * otherwise. That's because we don't know the SSRC until local description is
- * created.
- * In case of video and simulcast returns the the primarySSRC.
- * @returns {string} or {null}
- */
-JitsiLocalTrack.prototype.getSSRC = function() {
-    if (this.ssrc && this.ssrc.groups && this.ssrc.groups.length) {
-        return this.ssrc.groups[0].ssrcs[0];
-    } else if (this.ssrc && this.ssrc.ssrcs && this.ssrc.ssrcs.length) {
-        return this.ssrc.ssrcs[0];
-    }
-
-    return null;
-
 };
 
 /**
@@ -563,22 +597,29 @@ JitsiLocalTrack.prototype.getDeviceId = function() {
 };
 
 /**
+ * Returns the participant id which owns the track.
+ * @returns {string} the id of the participants. It corresponds to the Colibri
+ * endpoint id/MUC nickname in case of Jitsi-meet.
+ */
+JitsiLocalTrack.prototype.getParticipantId = function() {
+    return this.conference && this.conference.myUserId();
+};
+
+/**
  * Sets the value of bytes sent statistic.
- * @param bytesSent {integer} the new value (FIXME: what is an integer in js?)
+ * @param {TraceablePeerConnection} tpc the source of the "bytes sent" stat
+ * @param {number} bytesSent the new value
  * NOTE: used only for audio tracks to detect audio issues.
  */
-JitsiLocalTrack.prototype._setByteSent = function(bytesSent) {
+JitsiLocalTrack.prototype._setByteSent = function(tpc, bytesSent) {
     this._bytesSent = bytesSent;
-
-    // FIXME it's a shame that PeerConnection and ICE status does not belong
-    // to the RTC module and it has to be accessed through
-    // the conference(and through the XMPP chat room ???) instead
-    const iceConnectionState
-        = this.conference ? this.conference.getConnectionState() : null;
+    const iceConnectionState = tpc.getConnectionState();
 
     if (this._testByteSent && iceConnectionState === 'connected') {
         setTimeout(() => {
             if (this._bytesSent <= 0) {
+                logger.warn(`${this} 'bytes sent' <= 0: ${this._bytesSent}`);
+
                 // we are not receiving anything from the microphone
                 this._fireNoDataFromSourceEvent();
             }
@@ -674,6 +715,14 @@ JitsiLocalTrack.prototype._isReceivingData = function() {
     return this.stream.getTracks().some(track =>
         (!('readyState' in track) || track.readyState === 'live')
             && (!('muted' in track) || track.muted !== true));
+};
+
+/**
+ * Creates a text representation of this local track instance.
+ * @return {string}
+ */
+JitsiLocalTrack.prototype.toString = function() {
+    return `LocalTrack[${this.rtcId},${this.getType()}]`;
 };
 
 module.exports = JitsiLocalTrack;

--- a/modules/RTC/JitsiRemoteTrack.js
+++ b/modules/RTC/JitsiRemoteTrack.js
@@ -24,6 +24,8 @@ let ttfmTrackerVideoAttached = false;
  * @param {VideoType} videoType the type of the video if applicable
  * @param {string} ssrc the SSRC number of the Media Stream
  * @param {boolean} muted the initial muted state
+ * @param {boolean} isP2P indicates whether or not this track belongs to a P2P
+ * session
  * @constructor
  */
 function JitsiRemoteTrack(
@@ -35,7 +37,8 @@ function JitsiRemoteTrack(
         mediaType,
         videoType,
         ssrc,
-        muted) {
+        muted,
+        isP2P) {
     JitsiTrack.call(
         this,
         conference,
@@ -45,11 +48,12 @@ function JitsiRemoteTrack(
             // Nothing to do if the track is inactive.
         },
         mediaType,
-        videoType,
-        ssrc);
+        videoType);
     this.rtc = rtc;
+    this.ssrc = ssrc;
     this.ownerEndpointId = ownerEndpointId;
     this.muted = muted;
+    this.isP2P = isP2P;
 
     // we want to mark whether the track has been ever muted
     // to detect ttfm events for startmuted conferences, as it can significantly
@@ -216,6 +220,15 @@ JitsiRemoteTrack.prototype._attachTTFMTracker = function(container) {
     } else {
         container.addEventListener('canplay', this._playCallback.bind(this));
     }
+};
+
+/**
+ * Creates a text representation of this remote track instance.
+ * @return {string}
+ */
+JitsiRemoteTrack.prototype.toString = function() {
+    return `RemoteTrack[${this.ownerEndpointId}, ${this.getType()
+            }, p2p: ${this.isP2P}]`;
 };
 
 module.exports = JitsiRemoteTrack;

--- a/modules/RTC/JitsiTrack.js
+++ b/modules/RTC/JitsiTrack.js
@@ -67,16 +67,14 @@ function addMediaStreamInactiveHandler(mediaStream, handler) {
  *        onended/oninactive events of the stream.
  * @param trackMediaType the media type of the JitsiTrack
  * @param videoType the VideoType for this track if any
- * @param ssrc the SSRC of this track if known
  */
 function JitsiTrack(
-        conference,
-        stream,
-        track,
-        streamInactiveHandler,
-        trackMediaType,
-        videoType,
-        ssrc) {
+    conference,
+    stream,
+    track,
+    streamInactiveHandler,
+    trackMediaType,
+    videoType) {
     /**
      * Array with the HTML elements that are displaying the streams.
      * @type {Array}
@@ -84,7 +82,6 @@ function JitsiTrack(
     this.containers = [];
     this.conference = conference;
     this.stream = stream;
-    this.ssrc = ssrc;
     this.eventEmitter = new EventEmitter();
     this.audioLevel = -1;
     this.type = trackMediaType;

--- a/modules/RTC/LocalSdpMunger.js
+++ b/modules/RTC/LocalSdpMunger.js
@@ -1,0 +1,298 @@
+/* global __filename */
+
+import { getLogger } from 'jitsi-meet-logger';
+import * as MediaType from '../../service/RTC/MediaType';
+import { SdpTransformWrap } from '../xmpp/SdpTransformUtil';
+
+const logger = getLogger(__filename);
+
+/**
+ * Fakes local SDP, so that it will reflect detached local tracks associated
+ * with the {@link TraceablePeerConnection} and make operations like
+ * attach/detach and video mute/unmute local operations. That means it prevents
+ * from SSRC updates being sent to Jicofo/remote peer, so that there is no
+ * sRD/sLD cycle on the remote side.
+ */
+export default class LocalSdpMunger {
+
+    /**
+     * Creates new <tt>LocalSdpMunger</tt> instance.
+     *
+     * @param {TraceablePeerConnection} tpc
+     */
+    constructor(tpc) {
+        this.tpc = tpc;
+    }
+
+    /**
+     * Makes sure that detached local audio tracks stored in the parent
+     * {@link TraceablePeerConnection} are described in the local SDP.
+     * It's done in order to prevent from sending 'source-remove'/'source-add'
+     * Jingle notifications when local audio track is detached from
+     * the {@link TraceablePeerConnection}.
+     * @param {SdpTransformWrap} transformer the transformer instance which will
+     * be used to process the SDP.
+     * @return {boolean} <tt>true</tt> if there were any modifications to
+     * the SDP wrapped by <tt>transformer</tt>.
+     * @private
+     */
+    _addDetachedLocalAudioTracksToSDP(transformer) {
+        const localAudio = this.tpc.getLocalTracks(MediaType.AUDIO);
+
+        if (!localAudio.length) {
+            return false;
+        }
+        const audioMLine = transformer.selectMedia('audio');
+
+        if (!audioMLine) {
+            logger.error(
+                'Unable to hack local audio track SDP - no "audio" media');
+
+            return false;
+        }
+
+        if (audioMLine.direction === 'inactive') {
+            logger.error(
+                'Not doing local audio transform for "inactive" direction');
+
+            return false;
+        }
+
+        let modified = false;
+
+        for (const audioTrack of localAudio) {
+            const isAttached = audioTrack._isAttachedToPC(this.tpc);
+            const shouldFake = !isAttached;
+
+            logger.debug(
+                `${audioTrack} isAttached: ${isAttached
+                    } => should fake audio SDP ?: ${shouldFake}`);
+
+            if (!shouldFake) {
+                // not using continue increases indentation
+                // eslint-disable-next-line no-continue
+                continue;
+            }
+
+            // Inject removed SSRCs
+            const audioSSRC = this.tpc.getLocalSSRC(audioTrack);
+            const audioMSID = audioTrack.storedMSID;
+
+            if (!audioSSRC) {
+                logger.error(
+                    `Can't fake SDP for ${audioTrack} - no SSRC stored`);
+
+                // Aborts the forEach on this particular track,
+                // but will continue with the other ones
+                // eslint-disable-next-line no-continue
+                continue;
+            } else if (!audioMSID) {
+                logger.error(
+                    `No MSID stored for local audio SSRC: ${audioSSRC}`);
+
+                // eslint-disable-next-line no-continue
+                continue;
+            }
+
+            if (audioMLine.getSSRCCount() > 0) {
+                logger.debug(
+                    'Doing nothing - audio SSRCs are still there');
+
+                // audio SSRCs are still there
+                // eslint-disable-next-line no-continue
+                continue;
+            }
+
+            modified = true;
+
+            // We need to fake sendrecv
+            audioMLine.direction = 'sendrecv';
+
+            logger.debug(`Injecting audio SSRC: ${audioSSRC}`);
+            audioMLine.addSSRCAttribute({
+                id: audioSSRC,
+                attribute: 'cname',
+                value: `injected-${audioSSRC}`
+            });
+            audioMLine.addSSRCAttribute({
+                id: audioSSRC,
+                attribute: 'msid',
+                value: audioMSID
+            });
+        }
+
+        return modified;
+    }
+
+    /**
+     * Makes sure that detached (or muted) local video tracks associated with
+     * the parent {@link TraceablePeerConnection} are described in the local
+     * SDP. It's done in order to prevent from sending
+     * 'source-remove'/'source-add' Jingle notifications when local video track
+     * is detached from the {@link TraceablePeerConnection} (or muted).
+     *
+     * NOTE 1 video track is assumed
+     *
+     * @param {SdpTransformWrap} transformer the transformer instance which will
+     * be used to process the SDP.
+     * @return {boolean} <tt>true</tt> if there were any modifications to
+     * the SDP wrapped by <tt>transformer</tt>.
+     * @private
+     */
+    _addDetachedLocalVideoTracksToSDP(transformer) {
+        // Go over each video tracks and check if the SDP has to be changed
+        const localVideos = this.tpc.getLocalTracks(MediaType.VIDEO);
+
+        if (!localVideos.length) {
+            return false;
+        } else if (localVideos.length !== 1) {
+            logger.error(
+                'There is more than 1 video track ! '
+                    + 'Strange things may happen !', localVideos);
+        }
+
+        const videoMLine = transformer.selectMedia('video');
+
+        if (!videoMLine) {
+            logger.error(
+                'Unable to hack local video track SDP - no "video" media');
+
+            return false;
+        }
+
+        if (videoMLine.direction === 'inactive') {
+            logger.error(
+                'Not doing local video transform for "inactive" direction.');
+
+            return false;
+        }
+
+        let modified = false;
+
+        for (const videoTrack of localVideos) {
+            const isMuted = videoTrack.isMuted();
+            const muteInProgress = videoTrack.inMuteOrUnmuteProgress;
+            const isAttached = videoTrack._isAttachedToPC(this.tpc);
+            const shouldFakeSdp = isMuted || muteInProgress || !isAttached;
+
+            logger.debug(
+                `${videoTrack
+                 } isMuted: ${isMuted
+                 }, is mute in progress: ${muteInProgress
+                 }, is attached ? : ${isAttached
+                 } => should fake sdp ? : ${shouldFakeSdp}`);
+
+            if (!shouldFakeSdp) {
+                // eslint-disable-next-line no-continue
+                continue;
+            }
+
+            // Inject removed SSRCs
+            const requiredSSRCs
+                = this.tpc.isSimulcastOn()
+                    ? this.tpc.simulcast.ssrcCache
+                    : [ this.tpc.sdpConsistency.cachedPrimarySsrc ];
+
+            if (!requiredSSRCs.length) {
+                logger.error(
+                    `No SSRCs stored for: ${videoTrack} in ${this.tpc}`);
+
+                // eslint-disable-next-line no-continue
+                continue;
+            }
+            if (!videoMLine.getSSRCCount()) {
+                logger.error(
+                    'No video SSRCs found '
+                        + '(should be at least the recv-only one');
+
+                // eslint-disable-next-line no-continue
+                continue;
+            }
+
+            modified = true;
+
+            // We need to fake sendrecv
+            videoMLine.direction = 'sendrecv';
+
+            // Check if the recvonly has MSID
+            const primarySSRC = requiredSSRCs[0];
+
+            // FIXME the cname could come from the stream, but may
+            // turn out to be too complex. It is fine to come up
+            // with any value, as long as we only care about
+            // the actual SSRC values when deciding whether or not
+            // an update should be sent
+            const primaryCname = `injected-${primarySSRC}`;
+
+            for (const ssrcNum of requiredSSRCs) {
+                // Remove old attributes
+                videoMLine.removeSSRC(ssrcNum);
+
+                // Inject
+                logger.debug(
+                    `Injecting video SSRC: ${ssrcNum} for ${videoTrack}`);
+                videoMLine.addSSRCAttribute({
+                    id: ssrcNum,
+                    attribute: 'cname',
+                    value: primaryCname
+                });
+                videoMLine.addSSRCAttribute({
+                    id: ssrcNum,
+                    attribute: 'msid',
+                    value: videoTrack.storedMSID
+                });
+            }
+            if (requiredSSRCs.length > 1) {
+                const group = {
+                    ssrcs: requiredSSRCs.join(' '),
+                    semantics: 'SIM'
+                };
+
+                if (!videoMLine.findGroup(group.semantics, group.ssrcs)) {
+                    // Inject the group
+                    logger.debug(
+                        `Injecting SIM group for ${videoTrack}`, group);
+                    videoMLine.addSSRCGroup(group);
+                }
+            }
+
+            // Insert RTX
+            // FIXME in P2P RTX is used by Chrome regardless of config option
+            // status. Because of that 'source-remove'/'source-add'
+            // notifications are still sent to remove/add RTX SSRC and FID group
+            if (!this.tpc.options.disableRtx) {
+                this.tpc.rtxModifier.modifyRtxSsrcs2(videoMLine);
+            }
+        }
+
+        return modified;
+    }
+
+    /**
+     * Maybe modifies local description to fake local tracks SDP when those are
+     * either muted or detached from the <tt>PeerConnection</tt>.
+     *
+     * @param {object} desc the WebRTC SDP object instance for the local
+     * description.
+     */
+    maybeMungeLocalSdp(desc) {
+        // Nothing to be done in early stage when localDescription
+        // is not available yet
+        if (!desc || !desc.sdp) {
+            return;
+        }
+
+        const transformer = new SdpTransformWrap(desc.sdp);
+        let modified = this._addDetachedLocalAudioTracksToSDP(transformer);
+
+        if (this._addDetachedLocalVideoTracksToSDP(transformer)) {
+            modified = true;
+        }
+        if (modified) {
+            // Write
+            desc.sdp = transformer.toRawSDP();
+
+            // logger.info("Post TRANSFORM: ", desc.sdp);
+        }
+    }
+}

--- a/modules/RTC/RTCBrowserType.js
+++ b/modules/RTC/RTCBrowserType.js
@@ -25,6 +25,17 @@ const RTCBrowserType = {
     RTC_BROWSER_REACT_NATIVE: 'rtc_browser.react-native',
 
     /**
+     * Tells whether or not the <tt>MediaStream/tt> is removed from
+     * the <tt>PeerConnection</tt> and disposed on video mute (in order to turn
+     * off the camera device).
+     * @return {boolean} <tt>true</tt> if the current browser supports this
+     * strategy or <tt>false</tt> otherwise.
+     */
+    doesVideoMuteByStreamRemove() {
+        return !RTCBrowserType.isFirefox();
+    },
+
+    /**
      * Gets current browser type.
      * @returns {string}
      */
@@ -100,6 +111,15 @@ const RTCBrowserType = {
      */
     isElectron() {
         return currentBrowser === RTCBrowserType.RTC_BROWSER_ELECTRON;
+    },
+
+    /**
+     * Check whether or not the current browser support peer to peer connections
+     * @return {boolean} <tt>true</tt> if p2p is supported or <tt>false</tt>
+     * otherwise.
+     */
+    isP2PSupported() {
+        return !RTCBrowserType.isFirefox() && !RTCBrowserType.isReactNative();
     },
 
     /**

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -3,6 +3,9 @@
 
 import { getLogger } from 'jitsi-meet-logger';
 import * as GlobalOnErrorHandler from '../util/GlobalOnErrorHandler';
+import JitsiRemoteTrack from './JitsiRemoteTrack';
+import * as MediaType from '../../service/RTC/MediaType';
+import LocalSdpMunger from './LocalSdpMunger';
 import RTC from './RTC';
 import RTCBrowserType from './RTCBrowserType.js';
 import RTCEvents from '../../service/RTC/RTCEvents';
@@ -12,6 +15,7 @@ import RtxModifier from '../xmpp/RtxModifier.js';
 import SDP from '../xmpp/SDP';
 import SdpConsistency from '../xmpp/SdpConsistency.js';
 import SDPUtil from '../xmpp/SDPUtil';
+import * as SignalingEvents from '../../service/RTC/SignalingEvents';
 import transform from 'sdp-transform';
 
 const logger = getLogger(__filename);
@@ -27,6 +31,8 @@ const SIMULCAST_LAYERS = 3;
  * @param {SignalingLayer} signalingLayer the signaling layer instance
  * @param {object} iceConfig WebRTC 'PeerConnection' ICE config
  * @param {object} constraints WebRTC 'PeerConnection' constraints
+ * @param {boolean} isP2P indicates whether or not the new instance will be used
+ * in a peer to peer connection
  * @param {object} options <tt>TracablePeerConnection</tt> config options.
  * @param {boolean} options.disableSimulcast if set to 'true' will disable
  * the simulcast
@@ -47,6 +53,7 @@ function TraceablePeerConnection(
         signalingLayer,
         iceConfig,
         constraints,
+        isP2P,
         options) {
 
     /**
@@ -63,10 +70,73 @@ function TraceablePeerConnection(
     this.id = id;
 
     /**
+     * Indicates whether or not this instance is used in a peer to peer
+     * connection.
+     * @type {boolean}
+     */
+    this.isP2P = isP2P;
+
+    // FIXME: We should support multiple streams per jid.
+    /**
+     * The map holds remote tracks associated with this peer connection.
+     * It maps user's JID to media type and remote track
+     * (one track per media type per user's JID).
+     * @type {Map<string, Map<MediaType, JitsiRemoteTrack>>}
+     */
+    this.remoteTracks = new Map();
+
+    /**
+     * A map which stores local tracks mapped by {@link JitsiLocalTrack.rtcId}
+     * @type {Map<number, JitsiLocalTrack>}
+     */
+    this.localTracks = new Map();
+
+    /**
+     * @typedef {Object} TPCGroupInfo
+     * @property {string} semantics the SSRC groups semantics
+     * @property {Array<number>} ssrcs group's SSRCs in order where the first
+     * one is group's primary SSRC, the second one is secondary (RTX) and so
+     * on...
+     */
+    /**
+     * @typedef {Object} TPCSSRCInfo
+     * @property {Array<number>} ssrcs an array which holds all track's SSRCs
+     * @property {Array<TPCGroupInfo>} groups an array stores all track's SSRC
+     * groups
+     */
+    /**
+     * Holds the info about local track's SSRCs mapped per their
+     * {@link JitsiLocalTrack.rtcId}
+     * @type {Map<number, TPCSSRCInfo>}
+     */
+    this.localSSRCs = new Map();
+
+    /**
+     * The local ICE username fragment for this session.
+     */
+    this.localUfrag = null;
+
+    /**
+     * The remote ICE username fragment for this session.
+     */
+    this.remoteUfrag = null;
+
+    /**
      * The signaling layer which operates this peer connection.
      * @type {SignalingLayer}
      */
     this.signalingLayer = signalingLayer;
+
+    // SignalingLayer listeners
+    this._peerVideoTypeChanged = this._peerVideoTypeChanged.bind(this);
+    this.signalingLayer.on(
+        SignalingEvents.PEER_VIDEO_TYPE_CHANGED,
+        this._peerVideoTypeChanged);
+
+    this._peerMutedChanged = this._peerMutedChanged.bind(this);
+    this.signalingLayer.on(
+        SignalingEvents.PEER_MUTED_CHANGED,
+        this._peerMutedChanged);
     this.options = options;
     let RTCPeerConnectionType = null;
 
@@ -94,6 +164,13 @@ function TraceablePeerConnection(
     this.simulcast = new Simulcast({ numOfLayers: SIMULCAST_LAYERS,
         explodeRemoteSimulcast: false });
     this.sdpConsistency = new SdpConsistency();
+
+    /**
+     * Munges local SDP provided to the Jingle Session in order to prevent from
+     * sending SSRC updates on attach/detach and mute/unmute (for video).
+     * @type {LocalSdpMunger}
+     */
+    this.localSdpMunger = new LocalSdpMunger(this);
 
     /**
      * TracablePeerConnection uses RTC's eventEmitter
@@ -212,6 +289,8 @@ function TraceablePeerConnection(
             });
         }, 1000);
     }
+
+    logger.info(`Create new ${this}`);
 }
 
 /* eslint-enable max-params */
@@ -227,15 +306,140 @@ const dumpSDP = function(description) {
     return `type: ${description.type}\r\n${description.sdp}`;
 };
 
+
+/**
+ * Forwards the {@link peerconnection.iceConnectionState} state except that it
+ * will convert "completed" into "connected" where both mean that the ICE has
+ * succeeded and is up and running. We never see "completed" state for
+ * the JVB connection, but it started appearing for the P2P one. This method
+ * allows to adapt old logic to this new situation.
+ * @return {string}
+ */
+TraceablePeerConnection.prototype.getConnectionState = function() {
+    const state = this.peerconnection.iceConnectionState;
+
+    if (state === 'completed') {
+        return 'connected';
+    }
+
+    return state;
+};
+
+/**
+ * Tells whether or not this TPC instance is using Simulcast.
+ * @return {boolean} <tt>true</tt> if simulcast is enabled and active or
+ * <tt>false</tt> if it's turned off.
+ */
+TraceablePeerConnection.prototype.isSimulcastOn = function() {
+    return !this.options.disableSimulcast
+        && this.simulcast.isSupported()
+        && !this.isP2P;
+};
+
+/**
+ * Handles {@link SignalingEvents.PEER_VIDEO_TYPE_CHANGED}
+ * @param {string} endpointId the video owner's ID (MUC nickname)
+ * @param {VideoType} videoType the new value
+ * @private
+ */
+TraceablePeerConnection.prototype._peerVideoTypeChanged
+= function(endpointId, videoType) {
+    // Check if endpointId has a value to avoid action on random track
+    if (!endpointId) {
+        logger.error(`No endpointID on peerVideoTypeChanged ${this}`);
+
+        return;
+    }
+    const videoTrack = this.getRemoteTracks(endpointId, MediaType.VIDEO);
+
+    if (videoTrack.length) {
+        // NOTE 1 track per media type is assumed
+        videoTrack[0]._setVideoType(videoType);
+    }
+};
+
+/**
+ * Handles remote track mute / unmute events.
+ * @param {string} endpointId the track owner's identifier (MUC nickname)
+ * @param {MediaType} mediaType "audio" or "video"
+ * @param {boolean} isMuted the new mute state
+ * @private
+ */
+TraceablePeerConnection.prototype._peerMutedChanged
+= function(endpointId, mediaType, isMuted) {
+    // Check if endpointId is a value to avoid doing action on all remote tracks
+    if (!endpointId) {
+        logger.error('On peerMuteChanged - no endpoint ID');
+
+        return;
+    }
+    const track = this.getRemoteTracks(endpointId, mediaType);
+
+    if (track.length) {
+        // NOTE 1 track per media type is assumed
+        track[0].setMute(isMuted);
+    }
+};
+
+TraceablePeerConnection.prototype.getLocalTracks = function(mediaType) {
+    let tracks = Array.from(this.localTracks.values());
+
+    if (mediaType !== undefined) {
+        tracks = tracks.filter(track => track.getType() === mediaType);
+    }
+
+    return tracks;
+};
+
+/**
+ * Obtains all remote tracks currently known to this PeerConnection instance.
+ * @param {string} [endpointId] the track owner's identifier (MUC nickname)
+ * @param {MediaType} [mediaType] the remote tracks will be filtered
+ * by their media type if this argument is specified.
+ * @return {Array<JitsiRemoteTrack>}
+ */
+TraceablePeerConnection.prototype.getRemoteTracks
+= function(endpointId, mediaType) {
+    const remoteTracks = [];
+    const endpoints
+        = endpointId ? [ endpointId ] : this.remoteTracks.keys();
+
+    for (const endpoint of endpoints) {
+        const endpointTrackMap = this.remoteTracks.get(endpoint);
+
+        if (!endpointTrackMap) {
+
+            // Otherwise an empty Map() would have to be allocated above
+            // eslint-disable-next-line no-continue
+            continue;
+        }
+
+        for (const trackMediaType of endpointTrackMap.keys()) {
+            // per media type filtering
+            if (!mediaType || mediaType === trackMediaType) {
+                const mediaTrack = endpointTrackMap.get(trackMediaType);
+
+                if (mediaTrack) {
+                    remoteTracks.push(mediaTrack);
+                }
+            }
+        }
+    }
+
+    return remoteTracks;
+};
+
 /**
  * Called when new remote MediaStream is added to the PeerConnection.
  * @param {MediaStream} stream the WebRTC MediaStream for remote participant
  */
 TraceablePeerConnection.prototype._remoteStreamAdded = function(stream) {
-    if (!RTC.isUserStream(stream)) {
+    const streamId = RTC.getStreamID(stream);
+
+    if (!RTC.isUserStreamById(streamId)) {
         logger.info(
-            'Ignored remote \'stream added\' event for non-user stream',
-            stream);
+            `${this} ignored remote 'stream added' event for non-user stream`
+             + `id: ${streamId}`);
 
         return;
     }
@@ -278,7 +482,7 @@ TraceablePeerConnection.prototype._remoteTrackAdded = function(stream, track) {
     const streamId = RTC.getStreamID(stream);
     const mediaType = track.kind;
 
-    logger.info('Remote track added', streamId, mediaType);
+    logger.info(`${this} remote track added:`, streamId, mediaType);
 
     // look up an associated JID for a stream id
     if (!mediaType) {
@@ -341,25 +545,68 @@ TraceablePeerConnection.prototype._remoteTrackAdded = function(stream, track) {
         return;
     }
 
-    logger.log('associated ssrc', ownerEndpointId, trackSsrc);
+    logger.log(`${this} associated ssrc`, ownerEndpointId, trackSsrc);
 
     const peerMediaInfo
         = this.signalingLayer.getPeerMediaInfo(ownerEndpointId, mediaType);
 
     if (!peerMediaInfo) {
         GlobalOnErrorHandler.callErrorHandler(
-            new Error(`No peer media info available for: ${ownerEndpointId}`));
+            new Error(
+                `${this}: no peer media info available for ${
+                    ownerEndpointId}`));
 
-        // Abort
         return;
     }
 
     const muted = peerMediaInfo.muted;
     const videoType = peerMediaInfo.videoType; // can be undefined
 
-    this.rtc._createRemoteTrack(
+    this._createRemoteTrack(
         ownerEndpointId, stream, track, mediaType, videoType, trackSsrc, muted);
 };
+
+// FIXME cleanup params
+/* eslint-disable max-params */
+
+/**
+ * Initializes a new JitsiRemoteTrack instance with the data provided by
+ * the signaling layer and SDP.
+ *
+ * @param {string} ownerEndpointId the owner's endpoint ID (MUC nickname)
+ * @param {MediaStream} stream the WebRTC stream instance
+ * @param {MediaStreamTrack} track the WebRTC track instance
+ * @param {MediaType} mediaType the track's type of the media
+ * @param {VideoType} [videoType] the track's type of the video (if applicable)
+ * @param {string} ssrc the track's main SSRC number
+ * @param {boolean} muted the initial muted status
+ */
+TraceablePeerConnection.prototype._createRemoteTrack
+= function(ownerEndpointId, stream, track, mediaType, videoType, ssrc, muted) {
+    const remoteTrack
+        = new JitsiRemoteTrack(
+            this.rtc, this.rtc.conference,
+            ownerEndpointId,
+            stream, track, mediaType, videoType, ssrc, muted, this.isP2P);
+    let remoteTracksMap = this.remoteTracks.get(ownerEndpointId);
+
+    if (!remoteTracksMap) {
+        remoteTracksMap = new Map();
+        this.remoteTracks.set(ownerEndpointId, remoteTracksMap);
+    }
+
+    if (remoteTracksMap.has(mediaType)) {
+        logger.error(
+            `${this} overwriting remote track! ${remoteTrack}`,
+            ownerEndpointId, mediaType);
+    }
+    remoteTracksMap.set(mediaType, remoteTrack);
+
+    // FIXME not cool to use RTC's eventEmitter
+    this.rtc.eventEmitter.emit(RTCEvents.REMOTE_TRACK_ADDED, remoteTrack);
+};
+
+/* eslint-enable max-params */
 
 /**
  * Handles remote stream removal.
@@ -401,25 +648,23 @@ TraceablePeerConnection.prototype._remoteTrackRemoved
     const streamId = RTC.getStreamID(stream);
     const trackId = track && track.id;
 
-    logger.info('Remote track removed', streamId, trackId);
+    logger.info(`${this} - remote track removed: ${streamId}, ${trackId}`);
 
     if (!streamId) {
         GlobalOnErrorHandler.callErrorHandler(
-            new Error('Remote track removal failed - no stream ID'));
+            new Error(`${this} remote track removal failed - no stream ID`));
 
-        // Abort
         return;
     }
 
     if (!trackId) {
         GlobalOnErrorHandler.callErrorHandler(
-            new Error('Remote track removal failed - no track ID'));
+            new Error(`${this} remote track removal failed - no track ID`));
 
-        // Abort
         return;
     }
 
-    if (!this.rtc._removeRemoteTrack(streamId, trackId)) {
+    if (!this._removeRemoteTrack(streamId, trackId)) {
         // NOTE this warning is always printed when user leaves the room,
         // because we remove remote tracks manually on MUC member left event,
         // before the SSRCs are removed by Jicofo. In most cases it is fine to
@@ -431,9 +676,99 @@ TraceablePeerConnection.prototype._remoteTrackRemoved
         // behave unexpectedly (the "user left" event would come before "track
         // removed" events).
         logger.warn(
-            `Removed track not found for msid: ${streamId},
+            `${this} Removed track not found for msid: ${streamId},
              track id: ${trackId}`);
     }
+};
+
+/**
+ * Finds remote track by it's stream and track ids.
+ * @param {string} streamId the media stream id as defined by the WebRTC
+ * @param {string} trackId the media track id as defined by the WebRTC
+ * @return {JitsiRemoteTrack|undefined} the track's instance or
+ * <tt>undefined</tt> if not found.
+ * @private
+ */
+TraceablePeerConnection.prototype._getRemoteTrackById
+= function(streamId, trackId) {
+    // .find will break the loop once the first match is found
+    for (const endpointTrackMap of this.remoteTracks.values()) {
+        for (const mediaTrack of endpointTrackMap.values()) {
+            // FIXME verify and try to use ===
+            /* eslint-disable eqeqeq */
+            if (mediaTrack.getStreamId() == streamId
+                && mediaTrack.getTrackId() == trackId) {
+                return mediaTrack;
+            }
+
+            /* eslint-enable eqeqeq */
+        }
+    }
+
+    return undefined;
+};
+
+/**
+ * Removes all JitsiRemoteTracks associated with given MUC nickname
+ * (resource part of the JID). Returns array of removed tracks.
+ *
+ * @param {string} owner - The resource part of the MUC JID.
+ * @returns {JitsiRemoteTrack[]}
+ */
+TraceablePeerConnection.prototype.removeRemoteTracks = function(owner) {
+    const removedTracks = [];
+    const remoteTracksMap = this.remoteTracks.get(owner);
+
+    if (remoteTracksMap) {
+        const removedAudioTrack = remoteTracksMap.get(MediaType.AUDIO);
+        const removedVideoTrack = remoteTracksMap.get(MediaType.VIDEO);
+
+        removedAudioTrack && removedTracks.push(removedAudioTrack);
+        removedVideoTrack && removedTracks.push(removedVideoTrack);
+
+        this.remoteTracks.delete(owner);
+    }
+
+    logger.debug(
+        `${this} removed remote tracks for ${owner
+            } count: ${removedTracks.length}`);
+
+    return removedTracks;
+};
+
+/**
+ * Removes and disposes <tt>JitsiRemoteTrack</tt> identified by given stream and
+ * track ids.
+ *
+ * @param {string} streamId the media stream id as defined by the WebRTC
+ * @param {string} trackId the media track id as defined by the WebRTC
+ * @returns {JitsiRemoteTrack|undefined} the track which has been removed or
+ * <tt>undefined</tt> if no track matching given stream and track ids was
+ * found.
+ */
+TraceablePeerConnection.prototype._removeRemoteTrack
+= function(streamId, trackId) {
+    const toBeRemoved = this._getRemoteTrackById(streamId, trackId);
+
+    if (toBeRemoved) {
+        toBeRemoved.dispose();
+
+        const remoteTracksMap
+            = this.remoteTracks.get(toBeRemoved.getParticipantId());
+
+        // If _getRemoteTrackById succeeded it must be a valid value or
+        // we're good to crash
+        if (!remoteTracksMap.delete(toBeRemoved.getType())) {
+            logger.error(
+                `Failed to remove ${toBeRemoved} - type mapping messed up ?`);
+        }
+
+        // FIXME not cool to use RTC's eventEmitter
+        this.rtc.eventEmitter.emit(
+            RTCEvents.REMOTE_TRACK_REMOVED, toBeRemoved);
+    }
+
+    return toBeRemoved;
 };
 
 /**
@@ -515,7 +850,8 @@ function extractSSRCMap(desc) {
             if (!ssrcInfo) {
                 ssrcInfo = {
                     ssrcs: [],
-                    groups: []
+                    groups: [],
+                    msid
                 };
                 ssrcMap.set(msid, ssrcInfo);
             }
@@ -612,6 +948,17 @@ const normalizePlanB = function(desc) {
     });
 };
 
+/**
+ *
+ * @param {JitsiLocalTrack} localTrack
+ */
+TraceablePeerConnection.prototype.getLocalSSRC = function(localTrack) {
+    const ssrcInfo = this._getSSRC(localTrack.rtcId);
+
+    return ssrcInfo && ssrcInfo.ssrcs[0];
+};
+
+/* eslint-disable-next-line vars-on-top */
 const getters = {
     signalingState() {
         return this.peerconnection.signalingState;
@@ -631,7 +978,13 @@ const getters = {
                 dumpSDP(desc));
         }
 
-        return desc;
+        if (RTCBrowserType.doesVideoMuteByStreamRemove()) {
+            this.localSdpMunger.maybeMungeLocalSdp(desc);
+            logger.debug(
+                'getLocalDescription::postTransform (munge local SDP)', desc);
+        }
+
+        return desc || {};
     },
     remoteDescription() {
         let desc = this.peerconnection.remoteDescription;
@@ -645,7 +998,7 @@ const getters = {
                 'getRemoteDescription::postTransform (Plan B)', dumpSDP(desc));
         }
 
-        return desc;
+        return desc || {};
     }
 };
 
@@ -658,12 +1011,45 @@ Object.keys(getters).forEach(prop => {
     );
 });
 
-TraceablePeerConnection.prototype.addStream = function(stream, ssrcInfo) {
-    this.trace('addStream', stream ? stream.id : 'null');
-    if (stream) {
-        this.peerconnection.addStream(stream);
+TraceablePeerConnection.prototype._getSSRC = function(rtcId) {
+    return this.localSSRCs.get(rtcId);
+};
+
+/**
+ * Add {@link JitsiLocalTrack} to this TPC.
+ * @param {JitsiLocalTrack} track
+ */
+TraceablePeerConnection.prototype.addTrack = function(track) {
+    const rtcId = track.rtcId;
+
+    logger.info(`add ${track} to: ${this}`);
+
+    if (this.localTracks.has(rtcId)) {
+        logger.error(`${track} is already in ${this}`);
+
+        return;
     }
-    if (ssrcInfo && ssrcInfo.type === 'addMuted') {
+
+    this.localTracks.set(rtcId, track);
+    track._addPeerConnection(this);
+
+    const webrtcStream = track.getOriginalStream();
+
+    if (webrtcStream) {
+        this._addStream(webrtcStream);
+
+    // It's not ok for a track to not have a WebRTC stream if:
+    } else if (!RTCBrowserType.doesVideoMuteByStreamRemove()
+                || track.isAudioTrack()
+                || (track.isVideoTrack() && !track.isMuted())) {
+        logger.error(`${this} no WebRTC stream for: ${track}`);
+    }
+
+    // Muted video tracks do not have WebRTC stream
+    if (RTCBrowserType.doesVideoMuteByStreamRemove()
+            && track.isVideoTrack() && track.isMuted()) {
+        const ssrcInfo = this.generateNewStreamSSRCInfo(track);
+
         this.sdpConsistency.setPrimarySsrc(ssrcInfo.ssrcs[0]);
         const simGroup
             = ssrcInfo.groups.find(groupInfo => groupInfo.semantics === 'SIM');
@@ -689,12 +1075,297 @@ TraceablePeerConnection.prototype.addStream = function(stream, ssrcInfo) {
     }
 };
 
-TraceablePeerConnection.prototype.removeStream = function(stream) {
-    this.trace('removeStream', stream.id);
+/**
+ * Adds local track as part of the unmute operation.
+ * @param {JitsiLocalTrack} track the track to be added as part of the unmute
+ * operation
+ * @return {boolean} <tt>true</tt> if the state of underlying PC has changed and
+ * the renegotiation is required or <tt>false</tt> otherwise.
+ */
+TraceablePeerConnection.prototype.addTrackUnmute = function(track) {
+    if (!this._assertTrackBelongs('addTrackUnmute', track)) {
+        // Abort
+        return false;
+    }
 
-    // FF doesn't support this yet.
-    if (this.peerconnection.removeStream) {
-        this.peerconnection.removeStream(stream);
+    if (track._isAttachedToPC(this)) {
+        logger.info(`Adding ${track} as unmute to ${this}`);
+        const webRtcStream = track.getOriginalStream();
+
+        if (!webRtcStream) {
+            logger.error(
+                `Unable to add ${track} as unmute to ${this}`
+                    + ' - no WebRTC stream');
+
+            return false;
+        }
+        this._addStream(webRtcStream);
+
+        return true;
+    }
+
+    logger.info(`Not adding detached ${track} as unmute to ${this}`);
+
+    return false;
+};
+
+/**
+ * Adds WebRTC media stream to the underlying PeerConnection
+ * @param {MediaStream} mediaStream
+ * @private
+ */
+TraceablePeerConnection.prototype._addStream = function(mediaStream) {
+    this.peerconnection.addStream(mediaStream);
+};
+
+/**
+ * Removes WebRTC media stream from the underlying PeerConection
+ * @param {MediaStream} mediaStream
+ */
+TraceablePeerConnection.prototype._removeStream = function(mediaStream) {
+    if (RTCBrowserType.isFirefox()) {
+        this._handleFirefoxRemoveStream(mediaStream);
+    } else {
+        this.peerconnection.removeStream(mediaStream);
+    }
+};
+
+/**
+ * This method when called will check if given <tt>localTrack</tt> belongs to
+ * this TPC (that it has been previously added using {@link addTrack}). If the
+ * track does not belong an error message will be logged.
+ * @param {string} methodName the method name that will be logged in an error
+ * message
+ * @param {JitsiLocalTrack} localTrack
+ * @return {boolean} <tt>true</tt> if given local track belongs to this TPC or
+ * <tt>false</tt> otherwise.
+ * @private
+ */
+TraceablePeerConnection.prototype._assertTrackBelongs
+= function(methodName, localTrack) {
+    const doesBelong = this.localTracks.has(localTrack.rtcId);
+
+    if (!doesBelong) {
+        logger.error(
+            `${methodName}: ${localTrack} does not belong to ${this}`);
+    }
+
+    return doesBelong;
+};
+
+/**
+ * Checks whether given track is attached to this TPC. See
+ * {@link JitsiLocalTrack._isAttachedToPC} and {@link attachTrack} for more
+ * info.
+ * @param {JitsiLocalTrack} localTrack
+ * @return {boolean} <tt>true</tt> if attached or <tt>false</tt> otherwise
+ * @private
+ */
+TraceablePeerConnection.prototype._isTrackAttached = function(localTrack) {
+    return localTrack._isAttachedToPC(this);
+};
+
+/**
+ * Detaches given local track from this peer connection. A detached track will
+ * be removed from the underlying <tt>PeerConnection</tt>, but it will remain
+ * associated with this TPC. The {@link LocalSdpMunger} module will fake the
+ * local description exposed to {@link JingleSessionPC} in the way that track's
+ * SSRC will be still on place. It will prevent from any signaling updates and
+ * make other participants think that the track is still there even though they
+ * will receive no data for the underlying media stream.
+ * @param {JitsiLocalTrack} localTrack
+ */
+TraceablePeerConnection.prototype.detachTrack = function(localTrack) {
+    if (!this._assertTrackBelongs('detachTrack', localTrack)) {
+        // Abort
+        return;
+    } else if (!localTrack._isAttachedToPC(this)) {
+        // Abort
+        logger.error(
+            'An attempt to detach a not-attached '
+                + `${localTrack} from ${this} was made`);
+
+        return;
+    }
+
+    const webRtcStream = localTrack.getOriginalStream();
+
+    // Muted video track will not have WebRTC stream
+    if (webRtcStream) {
+        this._removeStream(webRtcStream);
+    } else if (localTrack.isVideoTrack() && localTrack.isMuted()) {
+        // It is normal that muted video track does not have WebRTC stream
+    } else {
+        logger.error(`${this} detach ${localTrack} - no WebRTC stream`);
+    }
+
+    localTrack._removePeerConnection(this);
+
+    logger.debug(`Detached ${localTrack} from ${this}`);
+};
+
+/**
+ * This operation reverts {@link detachTrack} (see for more info). The
+ * underlying <tt>MediaStream</tt> will be added back to the peer connection
+ * and {@link LocalSdpMunger} module will no longer fake it's SSRC through the
+ * local description exposed to {@link JingleSessionPC}.
+ * @param {JitsiLocalTrack} localTrack
+ */
+TraceablePeerConnection.prototype.attachTrack = function(localTrack) {
+    if (!this._assertTrackBelongs('attachTrack', localTrack)) {
+        // Abort
+        return;
+    } else if (localTrack._isAttachedToPC(this)) {
+        // Abort
+        logger.error(
+            'An attempt to attach an already attached '
+            + `${localTrack} to ${this} was made`);
+
+        return;
+    }
+
+    localTrack._addPeerConnection(this);
+
+    logger.debug(`Attached ${localTrack} to ${this}`);
+
+    // Muted video tracks are not added to the PeerConnection
+    if (!localTrack.isVideoTrack() || !localTrack.isMuted()) {
+        const webRtcStream = localTrack.getOriginalStream();
+
+        if (webRtcStream) {
+            this._addStream(webRtcStream);
+
+            return true;
+        }
+
+        logger.error(`${this} attach - no WebRTC stream for: ${localTrack}`);
+
+        return false;
+    }
+
+    logger.debug(`${this} attach ${localTrack} - not adding to PC`);
+
+    return false;
+};
+
+/**
+ * Remove local track from this TPC.
+ * @param {JitsiLocalTrack} localTrack the track to be removed from this TPC.
+ *
+ * FIXME It should probably remove a boolean just like {@link removeTrackMute}
+ *       The same applies to addTrack.
+ */
+TraceablePeerConnection.prototype.removeTrack = function(localTrack) {
+    const webRtcStream = localTrack.getOriginalStream();
+
+    this.trace(
+        'removeStream',
+        localTrack.rtcId, webRtcStream ? webRtcStream.id : undefined);
+
+    if (!this._assertTrackBelongs('removeStream', localTrack)) {
+        // Abort - nothing to be done here
+        return;
+    }
+    this.localTracks.delete(localTrack.rtcId);
+    this.localSSRCs.delete(localTrack.rtcId);
+
+    // A detached track will not require removal
+    if (this._isTrackAttached(localTrack)) {
+        localTrack._removePeerConnection(this);
+    }
+
+    if (webRtcStream) {
+        if (RTCBrowserType.isFirefox()) {
+            this._handleFirefoxRemoveStream(webRtcStream);
+        } else {
+            this.peerconnection.removeStream(webRtcStream);
+        }
+    }
+};
+
+/**
+ * Removes local track as part of the mute operation.
+ * @param {JitsiLocalTrack} localTrack the local track to be remove as part of
+ * the mute operation.
+ * @return {boolean} <tt>true</tt> if the underlying PeerConnection's state has
+ * changed and the renegotiation is required or <tt>false</tt> otherwise.
+ */
+TraceablePeerConnection.prototype.removeTrackMute = function(localTrack) {
+    const webRtcStream = localTrack.getOriginalStream();
+
+    this.trace(
+        'removeStreamMute',
+        localTrack.rtcId, webRtcStream ? webRtcStream.id : null);
+
+    if (!this._assertTrackBelongs('removeStreamMute', localTrack)) {
+        // Abort - nothing to be done here
+        return false;
+    } else if (!localTrack._isAttachedToPC(this)) {
+        // Abort - nothing to be done here
+        logger.warn(
+            `Not removing detached ${localTrack} as unmute from ${this}`);
+
+        return false;
+    }
+
+    if (webRtcStream) {
+        logger.info(
+            `Removing ${localTrack} as mute from ${this}`);
+        this._removeStream(webRtcStream);
+
+        return true;
+    }
+
+    logger.error(`removeStreamMute - no WebRTC stream for ${localTrack}`);
+
+    return false;
+};
+
+/**
+ * Remove stream handling for firefox
+ * @param stream: webrtc media stream
+ */
+TraceablePeerConnection.prototype._handleFirefoxRemoveStream
+= function(stream) {
+    if (!stream) {
+        // There is nothing to be changed
+        return;
+    }
+    let sender = null;
+
+    // On Firefox we don't replace MediaStreams as this messes up the
+    // m-lines (which can't be removed in Plan Unified) and brings a lot
+    // of complications. Instead, we use the RTPSender and remove just
+    // the track.
+    let track = null;
+
+    if (stream.getAudioTracks() && stream.getAudioTracks().length) {
+        track = stream.getAudioTracks()[0];
+    } else if (stream.getVideoTracks() && stream.getVideoTracks().length) {
+        track = stream.getVideoTracks()[0];
+    }
+
+    if (!track) {
+        logger.error('Cannot remove tracks: no tracks.');
+
+        return;
+    }
+
+    // Find the right sender (for audio or video)
+    this.peerconnection.getSenders().some(s => {
+        if (s.track === track) {
+            sender = s;
+
+            return true;
+        }
+
+        return false;
+    });
+
+    if (sender) {
+        this.peerconnection.removeTrack(sender);
+    } else {
+        logger.log('Cannot remove tracks: no RTPSender.');
     }
 };
 
@@ -705,89 +1376,100 @@ TraceablePeerConnection.prototype.createDataChannel = function(label, opts) {
 };
 
 TraceablePeerConnection.prototype.setLocalDescription
-    = function(description, successCallback, failureCallback) {
-        let d = description;
+= function(description, successCallback, failureCallback) {
+    let localSdp = description;
 
-        this.trace('setLocalDescription::preTransform', dumpSDP(d));
+    this.trace('setLocalDescription::preTransform', dumpSDP(localSdp));
 
-        // if we're running on FF, transform to Plan A first.
-        if (RTCBrowserType.usesUnifiedPlan()) {
-            d = this.interop.toUnifiedPlan(d);
-            this.trace(
-                'setLocalDescription::postTransform (Plan A)',
-                dumpSDP(d));
-        }
+    // if we're using unified plan, transform to it first.
+    if (RTCBrowserType.usesUnifiedPlan()) {
+        localSdp = this.interop.toUnifiedPlan(localSdp);
+        this.trace(
+            'setLocalDescription::postTransform (Unified Plan)',
+            dumpSDP(localSdp));
+    }
 
-        const self = this;
+    this.peerconnection.setLocalDescription(localSdp,
+        () => {
+            this.trace('setLocalDescriptionOnSuccess');
+            const localUfrag = SDPUtil.getUfrag(localSdp.sdp);
 
-        this.peerconnection.setLocalDescription(
-            d,
-            () => {
-                self.trace('setLocalDescriptionOnSuccess');
-                successCallback();
-            },
-            err => {
-                self.trace('setLocalDescriptionOnFailure', err);
-                self.eventEmitter.emit(
-                    RTCEvents.SET_LOCAL_DESCRIPTION_FAILED,
-                    err, self.peerconnection);
-                failureCallback(err);
+            if (localUfrag !== this.localUfrag) {
+                this.localUfrag = localUfrag;
+                this.rtc.eventEmitter.emit(
+                    RTCEvents.LOCAL_UFRAG_CHANGED, this, localUfrag);
             }
-        );
-    };
+            successCallback();
+        },
+        err => {
+            this.trace('setLocalDescriptionOnFailure', err);
+            this.eventEmitter.emit(
+                RTCEvents.SET_LOCAL_DESCRIPTION_FAILED,
+                err, this.peerconnection);
+            failureCallback(err);
+        }
+    );
+};
 
 TraceablePeerConnection.prototype.setRemoteDescription
-    = function(description, successCallback, failureCallback) {
-        this.trace('setRemoteDescription::preTransform', dumpSDP(description));
+= function(description, successCallback, failureCallback) {
+    this.trace('setRemoteDescription::preTransform', dumpSDP(description));
 
-        // TODO the focus should squeze or explode the remote simulcast
-        // eslint-disable-next-line no-param-reassign
-        description = this.simulcast.mungeRemoteDescription(description);
+    // TODO the focus should squeze or explode the remote simulcast
+    // eslint-disable-next-line no-param-reassign
+    description = this.simulcast.mungeRemoteDescription(description);
+    this.trace(
+        'setRemoteDescription::postTransform (simulcast)',
+        dumpSDP(description));
+
+    if (this.options.preferH264) {
+        const parsedSdp = transform.parse(description.sdp);
+        const videoMLine = parsedSdp.media.find(m => m.type === 'video');
+
+        SDPUtil.preferVideoCodec(videoMLine, 'h264');
+        description.sdp = transform.write(parsedSdp);
+    }
+
+    // If the browser uses unified plan, transform to it first
+    if (RTCBrowserType.usesUnifiedPlan()) {
+        description.sdp = this.rtxModifier.stripRtx(description.sdp);
         this.trace(
-            'setRemoteDescription::postTransform (simulcast)',
-            dumpSDP(description));
+                'setRemoteDescription::postTransform (stripRtx)',
+                dumpSDP(description));
 
-        if (this.options.preferH264) {
-            const parsedSdp = transform.parse(description.sdp);
-            const videoMLine = parsedSdp.media.find(m => m.type === 'video');
+        // eslint-disable-next-line no-param-reassign
+        description = this.interop.toUnifiedPlan(description);
+        this.trace(
+                'setRemoteDescription::postTransform (Plan A)',
+                dumpSDP(description));
+    } else {
+        // Plan B
+        // eslint-disable-next-line no-param-reassign
+        description = normalizePlanB(description);
+    }
 
-            SDPUtil.preferVideoCodec(videoMLine, 'h264');
-            description.sdp = transform.write(parsedSdp);
-        }
+    this.peerconnection.setRemoteDescription(
+        description,
+        () => {
+            this.trace('setRemoteDescriptionOnSuccess');
+            const remoteUfrag = SDPUtil.getUfrag(description.sdp);
 
-        // If the browser uses unified plan, transform to it first
-        if (RTCBrowserType.usesUnifiedPlan()) {
-            description.sdp = this.rtxModifier.stripRtx(description.sdp);
-            this.trace(
-                    'setRemoteDescription::postTransform (stripRtx)',
-                    dumpSDP(description));
-
-            // eslint-disable-next-line no-param-reassign
-            description = this.interop.toUnifiedPlan(description);
-            this.trace(
-                    'setRemoteDescription::postTransform (Plan A)',
-                    dumpSDP(description));
-        } else {
-            // Plan B
-            // eslint-disable-next-line no-param-reassign
-            description = normalizePlanB(description);
-        }
-
-        this.peerconnection.setRemoteDescription(
-            description,
-            () => {
-                this.trace('setRemoteDescriptionOnSuccess');
-                successCallback();
-            },
-            err => {
-                this.trace('setRemoteDescriptionOnFailure', err);
-                this.eventEmitter.emit(
-                    RTCEvents.SET_REMOTE_DESCRIPTION_FAILED,
-                    err,
-                    this.peerconnection);
-                failureCallback(err);
-            });
-    };
+            if (remoteUfrag !== this.remoteUfrag) {
+                this.remoteUfrag = remoteUfrag;
+                this.rtc.eventEmitter.emit(
+                    RTCEvents.REMOTE_UFRAG_CHANGED, this, remoteUfrag);
+            }
+            successCallback();
+        },
+        err => {
+            this.trace('setRemoteDescriptionOnFailure', err);
+            this.eventEmitter.emit(
+                RTCEvents.SET_REMOTE_DESCRIPTION_FAILED,
+                err,
+                this.peerconnection);
+            failureCallback(err);
+        });
+};
 
 /**
  * Makes the underlying TraceablePeerConnection generate new SSRC for
@@ -809,11 +1491,18 @@ TraceablePeerConnection.prototype.generateRecvonlySsrc = function() {
  */
 TraceablePeerConnection.prototype.clearRecvonlySsrc = function() {
     logger.info('Clearing primary video SSRC!');
-    this.sdpConsistency.clearSsrcCache();
+    this.sdpConsistency.clearVideoSsrcCache();
 };
 
 TraceablePeerConnection.prototype.close = function() {
     this.trace('stop');
+
+    // Off SignalingEvents
+    this.signalingLayer.off(
+        SignalingEvents.PEER_MUTED_CHANGED, this._peerMutedChanged);
+    this.signalingLayer.off(
+        SignalingEvents.PEER_VIDEO_TYPE_CHANGED, this._peerVideoTypeChanged);
+
     if (!this.rtc._removePeerConnection(this)) {
         logger.error('RTC._removePeerConnection returned false');
     }
@@ -884,20 +1573,44 @@ const _fixAnswerRFC4145Setup = function(offer, answer) {
 };
 
 TraceablePeerConnection.prototype.createAnswer
-    = function(successCallback, failureCallback, constraints) {
-        this.trace('createAnswer', JSON.stringify(constraints, null, ' '));
-        this.peerconnection.createAnswer(
-        answer => {
+= function(successCallback, failureCallback, constraints) {
+    this._createOfferOrAnswer(
+        false /* answer */, successCallback, failureCallback, constraints);
+};
+
+TraceablePeerConnection.prototype.createOffer
+= function(successCallback, failureCallback, constraints) {
+    this._createOfferOrAnswer(
+        true /* offer */, successCallback, failureCallback, constraints);
+};
+
+/* eslint-disable max-params */
+
+TraceablePeerConnection.prototype._createOfferOrAnswer
+= function(isOffer, successCallback, failureCallback, constraints) {
+    const logName = isOffer ? 'Offer' : 'Answer';
+
+    this.trace(`create${logName}`, JSON.stringify(constraints, null, ' '));
+
+    const offerOrAnswerMethod
+        = isOffer
+            ? this.peerconnection.createOffer.bind(this.peerconnection)
+            : this.peerconnection.createAnswer.bind(this.peerconnection);
+
+    offerOrAnswerMethod(
+        resultSdp => {
             try {
                 this.trace(
-                    'createAnswerOnSuccess::preTransform', dumpSDP(answer));
+                    `create${logName}OnSuccess::preTransform`,
+                    dumpSDP(resultSdp));
 
-                // if we're running on FF, transform to Plan A first.
+                // if we're using unified plan, transform to Plan B.
                 if (RTCBrowserType.usesUnifiedPlan()) {
                     // eslint-disable-next-line no-param-reassign
-                    answer = this.interop.toPlanB(answer);
-                    this.trace('createAnswerOnSuccess::postTransform (Plan B)',
-                        dumpSDP(answer));
+                    resultSdp = this.interop.toPlanB(resultSdp);
+                    this.trace(
+                        `create${logName}OnSuccess::postTransform (Plan B)`,
+                        dumpSDP(resultSdp));
                 }
 
                 /**
@@ -910,68 +1623,152 @@ TraceablePeerConnection.prototype.createAnswer
                  *  about unmapped ssrcs)
                  */
                 if (!RTCBrowserType.isFirefox()) {
-                    answer.sdp
+                    // If there are no local video tracks, then a "recvonly"
+                    // SSRC needs to be generated
+                    if (!this.getLocalTracks(MediaType.VIDEO).length) {
+                        this.sdpConsistency.setPrimarySsrc(
+                            SDPUtil.generateSsrc());
+                    }
+                    resultSdp.sdp
                         = this.sdpConsistency.makeVideoPrimarySsrcsConsistent(
-                            answer.sdp);
+                            resultSdp.sdp);
+                    resultSdp.sdp
+                        = this.sdpConsistency.makeAudioSSRCConsistent(
+                            resultSdp.sdp);
                     this.trace(
-                        'createAnswerOnSuccess::postTransform (make primary'
-                          + ' video ssrcs consistent)',
-                        dumpSDP(answer));
+                        `create${logName}OnSuccess::postTransform `
+                             + '(make primary audio/video ssrcs consistent)',
+                        dumpSDP(resultSdp));
                 }
 
                 // Add simulcast streams if simulcast is enabled
-                if (!this.options.disableSimulcast
-                        && this.simulcast.isSupported()) {
+                if (this.isSimulcastOn()) {
 
                     // eslint-disable-next-line no-param-reassign
-                    answer = this.simulcast.mungeLocalDescription(answer);
+                    resultSdp = this.simulcast.mungeLocalDescription(resultSdp);
                     this.trace(
-                        'createAnswerOnSuccess::postTransform (simulcast)',
-                        dumpSDP(answer));
+                        `create${logName}`
+                            + 'OnSuccess::postTransform (simulcast)',
+                        dumpSDP(resultSdp));
                 }
 
                 if (!this.options.disableRtx && RTCBrowserType.supportsRtx()) {
-                    answer.sdp = this.rtxModifier.modifyRtxSsrcs(answer.sdp);
+                    resultSdp.sdp
+                        = this.rtxModifier.modifyRtxSsrcs(resultSdp.sdp);
                     this.trace(
-                        'createAnswerOnSuccess::postTransform (rtx modifier)',
-                        dumpSDP(answer));
+                        `create${logName}`
+                             + 'OnSuccess::postTransform (rtx modifier)',
+                        dumpSDP(resultSdp));
                 }
 
                 // Fix the setup attribute (see _fixAnswerRFC4145Setup for
                 //  details)
-                const remoteDescription = new SDP(this.remoteDescription.sdp);
-                const localDescription = new SDP(answer.sdp);
+                if (!isOffer) {
+                    const remoteDescription
+                        = new SDP(this.remoteDescription.sdp);
+                    const localDescription = new SDP(resultSdp.sdp);
 
-                _fixAnswerRFC4145Setup(remoteDescription, localDescription);
-                answer.sdp = localDescription.raw;
+                    _fixAnswerRFC4145Setup(remoteDescription, localDescription);
+                    resultSdp.sdp = localDescription.raw;
+                }
 
-                this.eventEmitter.emit(RTCEvents.SENDRECV_STREAMS_CHANGED,
-                    extractSSRCMap(answer));
+                const ssrcMap = extractSSRCMap(resultSdp);
 
-                successCallback(answer);
+                logger.info('Got SSRC MAP: ', ssrcMap);
+
+                // Set up the ssrcHandler for the new track before we add it at
+                // the lower levels
+                this._applyLocalSSRCMap(ssrcMap);
+
+                successCallback(resultSdp);
             } catch (e) {
-                this.trace('createAnswerOnError', e);
-                this.trace('createAnswerOnError', dumpSDP(answer));
-                logger.error('createAnswerOnError', e, dumpSDP(answer));
+                this.trace(`create${logName}OnError`, e);
+                this.trace(`create${logName}OnError`, dumpSDP(resultSdp));
+                logger.error(
+                    `create${logName}OnError`, e, dumpSDP(resultSdp));
                 failureCallback(e);
             }
         },
         err => {
-            this.trace('createAnswerOnFailure', err);
-            this.eventEmitter.emit(RTCEvents.CREATE_ANSWER_FAILED, err,
-                this.peerconnection);
+            this.trace(`create${logName}OnFailure`, err);
+            const eventType
+                = isOffer
+                    ? RTCEvents.CREATE_OFFER_FAILED
+                    : RTCEvents.CREATE_ANSWER_FAILED;
+
+            this.eventEmitter.emit(eventType, err, this.peerconnection);
             failureCallback(err);
         },
         constraints);
-    };
+};
+
+/* eslint-enable max-params */
+
+/**
+ * Extract primary SSRC from given {@link TrackSSRCInfo} object.
+ * @param {TrackSSRCInfo} ssrcObj
+ * @return {number|null} the primary SSRC or <tt>null</tt>
+ */
+function extractPrimarySSRC(ssrcObj) {
+    if (ssrcObj && ssrcObj.groups && ssrcObj.groups.length) {
+        return ssrcObj.groups[0].ssrcs[0];
+    } else if (ssrcObj && ssrcObj.ssrcs && ssrcObj.ssrcs.length) {
+        return ssrcObj.ssrcs[0];
+    }
+
+    return null;
+}
+
+/**
+ * Applies SSRC map extracted from the latest local description to local tracks.
+ * @param {Map<string,TrackSSRCInfo>} ssrcMap
+ * @private
+ */
+TraceablePeerConnection.prototype._applyLocalSSRCMap = function(ssrcMap) {
+    for (const track of this.localTracks.values()) {
+        const trackMSID = track.getMSID();
+
+        if (ssrcMap.has(trackMSID)) {
+            const newSSRC = ssrcMap.get(trackMSID);
+
+            if (!newSSRC) {
+                logger.error(`No SSRC found for: ${trackMSID} in ${this}`);
+
+                return;
+            }
+            const oldSSRC = this.localSSRCs.get(track.rtcId);
+            const newSSRCNum = extractPrimarySSRC(newSSRC);
+            const oldSSRCNum = extractPrimarySSRC(oldSSRC);
+
+            // eslint-disable-next-line no-negated-condition
+            if (newSSRCNum !== oldSSRCNum) {
+                if (oldSSRCNum === null) {
+                    logger.info(
+                        `Setting new local SSRC for ${track} in ${this}`,
+                        newSSRC);
+                } else {
+                    logger.error(
+                        `Overwriting SSRC for ${track} ${trackMSID} in ${this
+                        } with: `, newSSRC);
+                }
+                this.localSSRCs.set(track.rtcId, newSSRC);
+            } else {
+                logger.debug(
+                    `Not updating local SSRC for ${track} ${trackMSID} to: `
+                        + `${newSSRCNum} in ${this}`);
+            }
+        } else {
+            logger.warn(`No local track matched with: ${trackMSID} in ${this}`);
+        }
+    }
+};
 
 TraceablePeerConnection.prototype.addIceCandidate
-
-        // eslint-disable-next-line no-unused-vars
-        = function(candidate, successCallback, failureCallback) {
+= function(candidate, successCallback, failureCallback) {
     // var self = this;
-            this.trace('addIceCandidate', JSON.stringify(candidate, null, ' '));
-            this.peerconnection.addIceCandidate(candidate);
+    this.trace('addIceCandidate', JSON.stringify(candidate, null, ' '));
+    this.peerconnection.addIceCandidate(
+        candidate, successCallback, failureCallback);
 
     /* maybe later
      this.peerconnection.addIceCandidate(candidate,
@@ -985,7 +1782,7 @@ TraceablePeerConnection.prototype.addIceCandidate
      }
      );
      */
-        };
+};
 
 TraceablePeerConnection.prototype.getStats = function(callback, errback) {
     // TODO: Is this the correct way to handle Opera, Temasys?
@@ -1005,16 +1802,24 @@ TraceablePeerConnection.prototype.getStats = function(callback, errback) {
 };
 
 /**
- * Generate ssrc info object for a stream with the following properties:
- * - ssrcs - Array of the ssrcs associated with the stream.
- * - groups - Array of the groups associated with the stream.
+ * Generates and stores new SSRC info object for given local track.
+ * The method should be called only for a video track being added to this TPC
+ * in the muted state (given that the current browser uses this strategy).
+ * @param {JitsiLocalTrack} track
+ * @return {TPCSSRCInfo}
  */
-TraceablePeerConnection.prototype.generateNewStreamSSRCInfo = function() {
-    let ssrcInfo = { ssrcs: [],
-        groups: [] };
+TraceablePeerConnection.prototype.generateNewStreamSSRCInfo = function(track) {
+    const rtcId = track.rtcId;
+    let ssrcInfo = this._getSSRC(rtcId);
 
-    if (!this.options.disableSimulcast
-        && this.simulcast.isSupported()) {
+    if (ssrcInfo) {
+        logger.error(`Will overwrite local SSRCs for track ID: ${rtcId}`);
+    }
+    if (this.isSimulcastOn()) {
+        ssrcInfo = {
+            ssrcs: [],
+            groups: []
+        };
         for (let i = 0; i < SIMULCAST_LAYERS; i++) {
             ssrcInfo.ssrcs.push(SDPUtil.generateSsrc());
         }
@@ -1046,8 +1851,19 @@ TraceablePeerConnection.prototype.generateNewStreamSSRCInfo = function() {
             });
         }
     }
+    ssrcInfo.msid = track.storedMSID;
+    this.localSSRCs.set(rtcId, ssrcInfo);
 
     return ssrcInfo;
+};
+
+/**
+ * Creates a text representation of this <tt>TraceablePeerConnection</tt>
+ * instance.
+ * @return {string}
+ */
+TraceablePeerConnection.prototype.toString = function() {
+    return `TPC[${this.id},p2p:${this.isP2P}]`;
 };
 
 module.exports = TraceablePeerConnection;

--- a/modules/connectivity/ConnectionQuality.js
+++ b/modules/connectivity/ConnectionQuality.js
@@ -214,8 +214,8 @@ export default class ConnectionQuality {
 
         conference.room.addListener(
             XMPPEvents.ICE_CONNECTION_STATE_CHANGED,
-            newState => {
-                if (newState === 'connected') {
+            (jingleSession, newState) => {
+                if (!jingleSession.isP2P && newState === 'connected') {
                     this._timeIceConnected = window.performance.now();
                 }
             });

--- a/modules/statistics/RTPStatsCollector.js
+++ b/modules/statistics/RTPStatsCollector.js
@@ -473,12 +473,15 @@ StatsCollector.prototype.processStatsReport = function() {
 
             if (!conferenceStatsTransport.some(
                     t =>
-                        t.ip === ip
-                        && t.type === type
-                        && t.localip === localip)) {
-                conferenceStatsTransport.push({ ip,
+                       t.ip === ip
+                       && t.type === type
+                       && t.localip === localip)) {
+                conferenceStatsTransport.push({
+                    ip,
                     type,
-                    localip });
+                    localip,
+                    p2p: this.peerconnection.isP2P
+                });
             }
             continue;
         }
@@ -495,7 +498,8 @@ StatsCollector.prototype.processStatsReport = function() {
             this.conferenceStats.transport.push({
                 ip: `${remote.ipAddress}:${remote.portNumber}`,
                 type: local.transport,
-                localip: `${local.ipAddress}:${local.portNumber}`
+                localip: `${local.ipAddress}:${local.portNumber}`,
+                p2p: this.peerconnection.isP2P
             });
         }
 
@@ -661,7 +665,8 @@ StatsCollector.prototype.processStatsReport = function() {
         this
     );
 
-    this.eventEmitter.emit(StatisticsEvents.BYTE_SENT_STATS, byteSentStats);
+    this.eventEmitter.emit(
+        StatisticsEvents.BYTE_SENT_STATS, this.peerconnection, byteSentStats);
 
     this.conferenceStats.bitrate
       = { 'upload': bitrateUpload,

--- a/modules/xmpp/RtxModifier.js
+++ b/modules/xmpp/RtxModifier.js
@@ -120,17 +120,30 @@ export default class RtxModifier {
 
             return sdpStr;
         }
+
+        return this.modifyRtxSsrcs2(videoMLine)
+            ? sdpTransformer.toRawSDP() : sdpStr;
+    }
+
+    /**
+     * Does the same thing as {@link modifyRtxSsrcs}, but takes the
+     *  {@link MLineWrap} instance wrapping video media as an argument.
+     * @param {MLineWrap} videoMLine
+     * @return {boolean} <tt>true</tt> if the SDP wrapped by
+     *  {@link SdpTransformWrap} has been modified or <tt>false</tt> otherwise.
+     */
+    modifyRtxSsrcs2(videoMLine) {
         if (videoMLine.direction === 'inactive'
-                || videoMLine.direction === 'recvonly') {
+            || videoMLine.direction === 'recvonly') {
             logger.debug('RtxModifier doing nothing, video '
                 + 'm line is inactive or recvonly');
 
-            return sdpStr;
+            return false;
         }
         if (videoMLine.getSSRCCount() < 1) {
             logger.debug('RtxModifier doing nothing, no video ssrcs present');
 
-            return sdpStr;
+            return false;
         }
         logger.debug('Current ssrc mapping: ', this.correspondingRtxSsrcs);
         const primaryVideoSsrcs = videoMLine.getPrimaryVideoSSRCs();
@@ -179,7 +192,9 @@ export default class RtxModifier {
                 correspondingRtxSsrc);
         }
 
-        return sdpTransformer.toRawSDP();
+        // FIXME we're not looking into much details whether the SDP has been
+        // modified or not once the precondition requirements are met.
+        return true;
     }
 
     /**

--- a/modules/xmpp/SDPDiffer.js
+++ b/modules/xmpp/SDPDiffer.js
@@ -92,8 +92,7 @@ SDPDiffer.prototype.getNewMedia = function() {
                 const mySsrcGroup = myMedia.ssrcGroups[i];
 
                 if (otherSsrcGroup.semantics === mySsrcGroup.semantics
-                    && arrayEquals(otherSsrcGroup.ssrcs,
-                                      [ mySsrcGroup.ssrcs ])) {
+                    && arrayEquals(otherSsrcGroup.ssrcs, mySsrcGroup.ssrcs)) {
 
                     matched = true;
                     break;

--- a/modules/xmpp/SDPUtil.js
+++ b/modules/xmpp/SDPUtil.js
@@ -547,6 +547,20 @@ const SDPUtil = {
     },
 
     /**
+     * Extracts the ICE username fragment from an SDP string.
+     * @param {string} sdp the SDP in raw text format
+     */
+    getUfrag(sdp) {
+        const ufragLines
+            = sdp.split('\n').filter(
+                    line => line.startsWith('a=ice-ufrag:'));
+
+        if (ufragLines.length > 0) {
+            return ufragLines[0].substr('a=ice-ufrag:'.length);
+        }
+    },
+
+    /**
      * Sets the given codecName as the preferred codec by
      *  moving it to the beginning of the payload types
      *  list (modifies the given mline in place).  If there

--- a/modules/xmpp/SdpConsistency.js
+++ b/modules/xmpp/SdpConsistency.js
@@ -21,15 +21,21 @@ export default class SdpConsistency {
      * Constructor
      */
     constructor() {
-        this.clearSsrcCache();
+        this.clearVideoSsrcCache();
+
+        /**
+         * Cached audio SSRC.
+         * @type {number|null}
+         */
+        this.cachedAudioSSRC = null;
     }
 
     /**
-     * Clear the cached primary and primary rtx ssrcs so that
+     * Clear the cached video primary and primary rtx ssrcs so that
      *  they will not be used for the next call to
      *  makeVideoPrimarySsrcsConsistent
      */
-    clearSsrcCache() {
+    clearVideoSsrcCache() {
         this.cachedPrimarySsrc = null;
     }
 
@@ -116,6 +122,54 @@ export default class SdpConsistency {
                     `Sdp-consistency caching primary ssrc ${
                         this.cachedPrimarySsrc}`);
             }
+        }
+
+        return sdpTransformer.toRawSDP();
+    }
+
+    /**
+     * Makes sure that audio SSRC is preserved between "detach" and "attach"
+     *  operations. The code assumes there can be only 1 audio track added to
+     *  the peer connection at a time.
+     * @param {string} sdpStr the sdp string to (potentially)
+     *  change to make the audio ssrc consistent
+     * @returns {string} a (potentially) modified sdp string
+     *  with ssrcs consistent with this class' cache
+     */
+    makeAudioSSRCConsistent(sdpStr) {
+        const sdpTransformer = new SdpTransformWrap(sdpStr);
+        const audioMLine = sdpTransformer.selectMedia('audio');
+
+        if (!audioMLine) {
+            logger.error(`No 'audio' media found in the sdp: ${sdpStr}`);
+
+            return sdpStr;
+        }
+        if (audioMLine.direction === 'inactive') {
+            logger.info(
+                'Sdp-consistency doing nothing, audio mline is inactive');
+
+            return sdpStr;
+        }
+
+        const audioSSRCObj = audioMLine.findSSRCByMSID(null);
+
+        if (audioSSRCObj) {
+            if (this.cachedAudioSSRC) {
+                const oldSSRC = audioSSRCObj.id;
+
+                if (oldSSRC !== this.cachedAudioSSRC) {
+                    logger.info(
+                        `Replacing audio SSRC ${
+                            oldSSRC} with ${this.cachedAudioSSRC}`);
+                    audioMLine.replaceSSRC(oldSSRC, this.cachedAudioSSRC);
+                }
+            } else {
+                this.cachedAudioSSRC = audioSSRCObj.id;
+                logger.info(`Storing audio SSRC: ${this.cachedAudioSSRC}`);
+            }
+        } else {
+            logger.info('Doing nothing - no audio stream in the SDP');
         }
 
         return sdpTransformer.toRawSDP();

--- a/modules/xmpp/SdpTransformUtil.js
+++ b/modules/xmpp/SdpTransformUtil.js
@@ -54,14 +54,28 @@ class MLineWrap {
     }
 
     /**
+     * Getter for the mLine's "ssrcs" array. If the array was undefined an empty
+     * one will be preassigned.
      *
+     * @return {Array<Object>} an array of 'sdp-transform' SSRC attributes
+     * objects.
      */
-    get _ssrcs() {
+    get ssrcs() {
         if (!this.mLine.ssrcs) {
             this.mLine.ssrcs = [];
         }
 
         return this.mLine.ssrcs;
+    }
+
+    /**
+     * Setter for the mLine's "ssrcs" array.
+     *
+     * @param {Array<Object>} ssrcs an array of 'sdp-transform' SSRC attributes
+     * objects.
+     */
+    set ssrcs(ssrcs) {
+        this.mLine.ssrcs = ssrcs;
     }
 
     /**
@@ -110,7 +124,7 @@ class MLineWrap {
      * <tt>undefined</tt> if no such attribute exists.
      */
     getSSRCAttrValue(ssrcNumber, attrName) {
-        const attribute = this._ssrcs.find(
+        const attribute = this.ssrcs.find(
             ssrcObj => ssrcObj.id === ssrcNumber
             && ssrcObj.attribute === attrName);
 
@@ -138,7 +152,7 @@ class MLineWrap {
      * the 'sdp-transform' lib.
      */
     addSSRCAttribute(ssrcObj) {
-        this._ssrcs.push(ssrcObj);
+        this.ssrcs.push(ssrcObj);
     }
 
     /**
@@ -180,6 +194,18 @@ class MLineWrap {
     }
 
     /**
+     * @param {string|null} msid the media stream id or <tt>null</tt> to match
+     * the first SSRC object with any 'msid' value.
+     * @return {Object|undefined} the SSRC object as defined by 'sdp-transform'
+     * lib.
+     */
+    findSSRCByMSID(msid) {
+        return this.ssrcs.find(
+            ssrcObj => ssrcObj.attribute === 'msid'
+                && (msid === null || ssrcObj.value === msid));
+    }
+
+    /**
      * Gets the SSRC count for the underlying media description.
      * @return {number}
      */
@@ -212,7 +238,7 @@ class MLineWrap {
         const numSsrcs = _getSSRCCount(this.mLine);
 
         if (numSsrcs === 1) {
-            // Not using _ssrcs on purpose here
+            // Not using "ssrcs" getter on purpose here
             return this.mLine.ssrcs[0].id;
         }
 
@@ -252,7 +278,7 @@ class MLineWrap {
      * @return {Array.<number>} an array with all SSRC as numbers.
      */
     getSSRCs() {
-        return this._ssrcs
+        return this.ssrcs
             .map(ssrcInfo => ssrcInfo.id)
             .filter((ssrc, index, array) => array.indexOf(ssrc) === index);
     }

--- a/modules/xmpp/SignalingLayerImpl.js
+++ b/modules/xmpp/SignalingLayerImpl.js
@@ -1,0 +1,104 @@
+/* global __filename */
+
+import { getLogger } from 'jitsi-meet-logger';
+import * as MediaType from '../../service/RTC/MediaType';
+import * as SignalingEvents from '../../service/RTC/SignalingEvents';
+import SignalingLayer from '../../service/RTC/SignalingLayer';
+
+const logger = getLogger(__filename);
+
+/**
+ * Default XMPP implementation of the {@link SignalingLayer} interface. Obtains
+ * the data from the MUC presence.
+ */
+export default class SignalingLayerImpl extends SignalingLayer {
+    /**
+     * Creates new instance.
+     */
+    constructor() {
+        super();
+
+        /**
+         * A map that stores SSRCs of remote streams. And is used only locally
+         * We store the mapping when jingle is received, and later is used
+         * onaddstream webrtc event where we have only the ssrc
+         * FIXME: This map got filled and never cleaned and can grow during long
+         * conference
+         * @type {Map<string, string>} maps SSRC number to jid
+         */
+        this.ssrcOwners = new Map();
+
+        /**
+         *
+         * @type {ChatRoom|null}
+         */
+        this.chatRoom = null;
+    }
+
+    /**
+     * Sets the <tt>ChatRoom</tt> instance used and binds presence listeners.
+     * @param {ChatRoom} room
+     */
+    setChatRoom(room) {
+        const oldChatRoom = this.chatRoom;
+
+        this.chatRoom = room;
+        if (oldChatRoom) {
+            oldChatRoom.removePresenceListener(
+                'audiomuted', this._audioMuteHandler);
+            oldChatRoom.removePresenceListener(
+                'videomuted', this._videoMuteHandler);
+            oldChatRoom.removePresenceListener(
+                'videoType', this._videoTypeHandler);
+        }
+        if (room) {
+            // SignalingEvents
+            this._audioMuteHandler = (node, from) => {
+                this.eventEmitter.emit(
+                    SignalingEvents.PEER_MUTED_CHANGED,
+                    from, MediaType.AUDIO, node.value === 'true');
+            };
+            room.addPresenceListener('audiomuted', this._audioMuteHandler);
+
+            this._videoMuteHandler = (node, from) => {
+                this.eventEmitter.emit(
+                    SignalingEvents.PEER_MUTED_CHANGED,
+                    from, MediaType.VIDEO, node.value === 'true');
+            };
+            room.addPresenceListener('videomuted', this._videoMuteHandler);
+
+            this._videoTypeHandler = (node, from) => {
+                this.eventEmitter.emit(
+                    SignalingEvents.PEER_VIDEO_TYPE_CHANGED,
+                    from, node.value);
+            };
+            room.addPresenceListener('videoType', this._videoTypeHandler);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    getPeerMediaInfo(owner, mediaType) {
+        if (this.chatRoom) {
+            return this.chatRoom.getMediaPresenceInfo(owner, mediaType);
+        }
+        logger.error('Requested peer media info, before room was set');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    getSSRCOwner(ssrc) {
+        return this.ssrcOwners.get(ssrc);
+    }
+
+    /**
+     * Set an SSRC owner.
+     * @param {string} ssrc an SSRC to be owned
+     * @param {string} endpointId owner's ID (MUC nickname)
+     */
+    setSSRCOwner(ssrc, endpointId) {
+        this.ssrcOwners.set(ssrc, endpointId);
+    }
+}

--- a/modules/xmpp/strophe.jingle.js
+++ b/modules/xmpp/strophe.jingle.js
@@ -1,11 +1,13 @@
-/* global $, $iq, Strophe */
+/* global $, $iq, __filename, Strophe */
 
 import { getLogger } from 'jitsi-meet-logger';
 const logger = getLogger(__filename);
 
 import JingleSessionPC from './JingleSessionPC';
+import * as JingleSessionState from './JingleSessionState';
 import XMPPEvents from '../../service/xmpp/XMPPEvents';
 import GlobalOnErrorHandler from '../util/GlobalOnErrorHandler';
+import RandomUtil from '../util/RandomUtil';
 import Statistics from '../statistics/statistics';
 import ConnectionPlugin from './ConnectionPlugin';
 
@@ -18,16 +20,24 @@ import ConnectionPlugin from './ConnectionPlugin';
  */
 class JingleConnectionPlugin extends ConnectionPlugin {
     /**
-     *
-     * @param xmpp
-     * @param eventEmitter
+     * Creates new <tt>JingleConnectionPlugin</tt>
+     * @param {XMPP} xmpp
+     * @param {EventEmitter} eventEmitter
+     * @param {Array<Object>} p2pStunServers an array which is part of the ice
+     * config passed to the <tt>PeerConnection</tt> with the structure defined
+     * by the WebRTC standard.
      */
-    constructor(xmpp, eventEmitter) {
+    constructor(xmpp, eventEmitter, p2pStunServers) {
         super();
         this.xmpp = xmpp;
         this.eventEmitter = eventEmitter;
         this.sessions = {};
-        this.iceConfig = { iceServers: [] };
+        this.jvbIceConfig = { iceServers: [ ] };
+        this.p2pIceConfig = { iceServers: [ ] };
+        if (Array.isArray(p2pStunServers)) {
+            logger.info('Configured STUN servers: ', p2pStunServers);
+            this.p2pIceConfig.iceServers = p2pStunServers;
+        }
         this.mediaConstraints = {
             mandatory: {
                 'OfferToReceiveAudio': true,
@@ -128,15 +138,27 @@ class JingleConnectionPlugin extends ConnectionPlugin {
                 const videoMuted = startMuted.attr('video');
 
                 this.eventEmitter.emit(XMPPEvents.START_MUTED_FROM_FOCUS,
-                            audioMuted === 'true', videoMuted === 'true');
+                        audioMuted === 'true', videoMuted === 'true');
             }
+
+            // FIXME that should work most of the time, but we'd have to
+            // think how secure it is to assume that user with "focus"
+            // nickname is Jicofo.
+            const isP2P = Strophe.getResourceFromJid(fromJid) !== 'focus';
+
+            logger.info(
+                `Marking session from ${fromJid
+                } as ${isP2P ? '' : '*not*'} P2P`);
             sess = new JingleSessionPC(
                         $(iq).find('jingle').attr('sid'),
                         $(iq).attr('to'),
                         fromJid,
                         this.connection,
                         this.mediaConstraints,
-                        this.iceConfig, this.xmpp.options);
+                        isP2P ? this.p2pIceConfig : this.jvbIceConfig,
+                        isP2P /* P2P */,
+                        false /* initiator */,
+                        this.xmpp.options);
 
             this.sessions[sess.sid] = sess;
 
@@ -144,6 +166,16 @@ class JingleConnectionPlugin extends ConnectionPlugin {
                     sess, $(iq).find('>jingle'), now);
             Statistics.analytics.sendEvent(
                     'xmpp.session-initiate', { value: now });
+            break;
+        }
+        case 'session-accept': {
+            this.eventEmitter.emit(
+                XMPPEvents.CALL_ACCEPTED, sess, $(iq).find('>jingle'));
+            break;
+        }
+        case 'transport-info': {
+            this.eventEmitter.emit(
+                XMPPEvents.TRANSPORT_INFO, sess, $(iq).find('>jingle'));
             break;
         }
         case 'session-terminate': {
@@ -156,9 +188,10 @@ class JingleConnectionPlugin extends ConnectionPlugin {
                     = $(iq).find('>jingle>reason>:first')[0].tagName;
                 reasonText = $(iq).find('>jingle>reason>text').text();
             }
+            sess.state = JingleSessionState.ENDED;
             this.terminate(sess.sid, reasonCondition, reasonText);
             this.eventEmitter.emit(XMPPEvents.CALL_ENDED,
-                    sess, reasonCondition, reasonText);
+                sess, reasonCondition, reasonText);
             break;
         }
         case 'transport-replace':
@@ -200,6 +233,31 @@ class JingleConnectionPlugin extends ConnectionPlugin {
         this.connection.send(ack);
 
         return true;
+    }
+
+    /**
+     * Creates new <tt>JingleSessionPC</tt> meant to be used in a direct P2P
+     * connection, configured as 'initiator'.
+     * @param {string} me our JID
+     * @param {string} peer remote participant's JID
+     * @return {JingleSessionPC}
+     */
+    newP2PJingleSession(me, peer) {
+        const sess
+            = new JingleSessionPC(
+                    RandomUtil.randomHexString(12),
+                    me,
+                    peer,
+                    this.connection,
+                    this.mediaConstraints,
+                    this.p2pIceConfig,
+                    true /* P2P */,
+                    true /* initiator */,
+                    this.xmpp.options);
+
+        this.sessions[sess.sid] = sess;
+
+        return sess;
     }
 
     /**
@@ -296,7 +354,7 @@ class JingleConnectionPlugin extends ConnectionPlugin {
                     }
                     }
                 });
-                this.iceConfig.iceServers = iceservers;
+                this.jvbIceConfig.iceServers = iceservers;
             }, err => {
                 logger.warn('getting turn credentials failed', err);
                 logger.warn('is mod_turncredentials or similar installed?');
@@ -331,8 +389,8 @@ class JingleConnectionPlugin extends ConnectionPlugin {
 
 /* eslint-enable newline-per-chained-call */
 
-module.exports = function(XMPP, eventEmitter) {
+module.exports = function(XMPP, eventEmitter, p2pStunServers) {
     Strophe.addConnectionPlugin(
         'jingle',
-        new JingleConnectionPlugin(XMPP, eventEmitter));
+        new JingleConnectionPlugin(XMPP, eventEmitter, p2pStunServers));
 };

--- a/modules/xmpp/xmpp.js
+++ b/modules/xmpp/xmpp.js
@@ -36,8 +36,10 @@ function createConnection(token, bosh = '/http-bind') {
  */
 export default class XMPP extends Listenable {
     /**
-     *
-     * @param options
+     * FIXME describe all options
+     * @param {Object} options
+     * @param {Array<Object>} options.p2pStunServers see
+     * {@link JingleConnectionPlugin} for more details.
      * @param token
      */
     constructor(options, token) {
@@ -442,7 +444,7 @@ export default class XMPP extends Listenable {
      */
     _initStrophePlugins() {
         initEmuc(this);
-        initJingle(this, this.eventEmitter);
+        initJingle(this, this.eventEmitter, this.options.p2pStunServers);
         initStropheUtil();
         initPing(this);
         initRayo();

--- a/service/RTC/RTCEvents.js
+++ b/service/RTC/RTCEvents.js
@@ -10,12 +10,6 @@ const RTCEvents = {
      */
     CREATE_OFFER_FAILED: 'rtc.create_offer_failed',
     RTC_READY: 'rtc.ready',
-
-    /**
-     * FIXME: rename to something closer to "local streams SDP changed"
-     * Indicates that the local sendrecv streams in local SDP are changed.
-     */
-    SENDRECV_STREAMS_CHANGED: 'rtc.sendrecv_streams_changed',
     DATA_CHANNEL_OPEN: 'rtc.data_channel_open',
     ENDPOINT_CONN_STATUS_CHANGED: 'rtc.endpoint_conn_status_changed',
     LASTN_CHANGED: 'rtc.lastn_changed',
@@ -26,14 +20,7 @@ const RTCEvents = {
 
     /**
      * Event fired when we remote track is added to the conference.
-     * The following structure is passed as an argument:
-     * {
-     *   stream: the WebRTC MediaStream instance
-     *   track: the WebRTC MediaStreamTrack
-     *   mediaType: the MediaType instance
-     *   owner: the MUC JID of the stream owner
-     *   muted: a boolean indicating initial 'muted' status of the track or
-      *         'null' if unknown
+     * 1st event argument is the added <tt>JitsiRemoteTrack</tt> instance.
      **/
     REMOTE_TRACK_ADDED: 'rtc.remote_track_added',
 
@@ -43,9 +30,7 @@ const RTCEvents = {
 
     /**
      * Indicates that the remote track has been removed from the conference.
-     * 1st event argument is the ID of the parent WebRTC stream to which
-     * the track being removed belongs to.
-     * 2nd event argument is the ID of the removed track.
+     * 1st event argument is the removed {@link JitsiRemoteTrack} instance.
      */
     REMOTE_TRACK_REMOVED: 'rtc.remote_track_removed',
 
@@ -70,8 +55,25 @@ const RTCEvents = {
      * Indicates that a message from another participant is received on
      * data channel.
      */
-    ENDPOINT_MESSAGE_RECEIVED:
-        'rtc.endpoint_message_received'
+    ENDPOINT_MESSAGE_RECEIVED: 'rtc.endpoint_message_received',
+
+    /**
+     * Designates an event indicating that the local ICE username fragment of
+     * the jingle session has changed.
+     * The first argument of the vent is <tt>TraceablePeerConnection</tt> which
+     * is the source of the event.
+     * The second argument is the actual "ufrag" string.
+     */
+    LOCAL_UFRAG_CHANGED: 'rtc.local_ufrag_changed',
+
+    /**
+     * Designates an event indicating that the local ICE username fragment of
+     * the jingle session has changed.
+     * The first argument of the vent is <tt>TraceablePeerConnection</tt> which
+     * is the source of the event.
+     * The second argument is the actual "ufrag" string.
+     */
+    REMOTE_UFRAG_CHANGED: 'rtc.remote_ufrag_changed'
 };
 
 module.exports = RTCEvents;

--- a/service/RTC/SignalingEvents.js
+++ b/service/RTC/SignalingEvents.js
@@ -1,0 +1,14 @@
+/**
+ * Event triggered when participant's muted status changes.
+ * @param {string} endpointId the track owner's identifier (MUC nickname)
+ * @param {MediaType} mediaType "audio" or "video"
+ * @param {boolean} isMuted the new muted state
+ */
+export const PEER_MUTED_CHANGED = 'signaling.peerMuted';
+
+/**
+ * Event triggered when participant's video type changes.
+ * @param {string} endpointId the video owner's ID (MUC nickname)
+ * @param {VideoType} videoType the new value
+ */
+export const PEER_VIDEO_TYPE_CHANGED = 'signaling.peerVideoType';

--- a/service/RTC/SignalingLayer.js
+++ b/service/RTC/SignalingLayer.js
@@ -1,19 +1,21 @@
 
+import Listenable from '../../modules/util/Listenable';
+
 /**
  * An object that carries the info about specific media type advertised by
- * participant in the signalling channel.
+ * participant in the signaling channel.
  * @typedef {Object} PeerMediaInfo
  * @property {boolean} muted indicates if the media is currently muted
  * @property {VideoType|undefined} videoType the type of the video if applicable
  */
 
 /**
- * Interface used to expose the information carried over the signalling channel
+ * Interface used to expose the information carried over the signaling channel
  * which is not available to the RTC module in the media SDP.
  *
  * @interface SignalingLayer
  */
-export default class SignalingLayer {
+export default class SignalingLayer extends Listenable {
 
     /**
      * Obtains the endpoint ID for given SSRC.

--- a/service/xmpp/XMPPEvents.js
+++ b/service/xmpp/XMPPEvents.js
@@ -10,6 +10,11 @@ const XMPPEvents = {
     AUTHENTICATION_REQUIRED: 'xmpp.authentication_required',
     BRIDGE_DOWN: 'xmpp.bridge_down',
 
+    /**
+     * Triggered when 'session-accept' is received from the responder.
+     */
+    CALL_ACCEPTED: 'xmpp.callaccepted.jingle',
+
     // Designates an event indicating that an offer (e.g. Jingle
     // session-initiate) was received.
     CALL_INCOMING: 'xmpp.callincoming.jingle',
@@ -21,6 +26,11 @@ const XMPPEvents = {
     CALL_ENDED: 'xmpp.callended.jingle',
     CHAT_ERROR_RECEIVED: 'xmpp.chat_error_received',
     CONFERENCE_SETUP_FAILED: 'xmpp.conference_setup_failed',
+
+    /**
+     * This event is triggered when the ICE connects for the first time.
+     */
+    CONNECTION_ESTABLISHED: 'xmpp.connection.connected',
 
     // Designates an event indicating that the connection to the XMPP server
     // failed.
@@ -181,16 +191,14 @@ const XMPPEvents = {
     // changed.
     SUBJECT_CHANGED: 'xmpp.subject_changed',
 
+    // FIXME: how does it belong to XMPP ? - it's detected by the PeerConnection
     // suspending detected
     SUSPEND_DETECTED: 'xmpp.suspend_detected',
 
-    // Designates an event indicating that the local ICE username fragment of
-    // the jingle session has changed.
-    LOCAL_UFRAG_CHANGED: 'xmpp.local_ufrag_changed',
-
-    // Designates an event indicating that the local ICE username fragment of
-    // the jingle session has changed.
-    REMOTE_UFRAG_CHANGED: 'xmpp.remote_ufrag_changed',
+    /**
+     * Event fired when 'transport-info' with new ICE candidates is received.
+     */
+    TRANSPORT_INFO: 'xmpp.transportinfo.jingle',
 
     // Designates an event indicating that the local ICE connection state has
     // changed.


### PR DESCRIPTION
* ref(RTC): store remote tracks in peer TPC

In order to implement P2P <-> JVB connection switching we need to
be able to associate remote tracks with the TraceablePeerConnections.

* feat(ChatRoom): multiple presence handlers

Add support for more than 1 presence handler per tag name.

* feat(JitsiLocalTrack): update stored MSID

* ref(stats): add peer connection arg to BYTE_SENT_STATS

Required to store local SSRCs in TraceablePeerConnection.

* ref: change local SSRCs strategy

* fix: generate recvonly SSRC if 0 video tracks

Video SSRC has to be generated for the recvonly stream if there are no
video tracks in the PeerConnection.

* feat: add "attach" and "detach" methods

* feat(jitsi tracks): improve logging

Adds toString methods and improve log messages around local and remote
tracks.

* ref(modify SSRCs): optimisations + fixes

- adds _doRenegotiate to JingleSessionPC that wraps some of
  the duplicated logic
- fixes problems with attach/detach
- renames methods to reflect what that they really do (operate on
  JitsiTrack rather than streams)

* ref(JingleSessionPC): remove duplication

Extracts common code for the 'modificationQueue' execution

* ref(VideoMuteSdpHack): rename, add docs, fix minor

Renames, adds docs and moves 'modified' flag and media direction
modification.

* ref(TPC): add 'isSimulcastOn'

* ref(MungeLocalSdp): move to RTC module

* ref: move "ufrag" events to the RTC module

* ref(JitsiConference): use promises for mute

* feat(XMPPEvents): add CONNECTION_ESTABLISHED

* feat: add peer to peer

* fix(P2P): deal with everyone's a moderator + fixes

* feat(P2P): implement "backToP2PDelay"

* fix(TPC): crash on FF accessing LD/RD

Firefox return null/undefined for localDescription/remoteDescription
objects if they have not been set yet, while Chrome does return empty
object instead. This commit makes the behaviour consistent by making
sure that at least empty object is returned for all browsers.

* fix(TPC): replace isFirefox with feature

* fix(JSPC): fix renegotiate crash on FF

FF does not allow to call 'createAnswer' in 'have-local-offer' state

* fix(JSPC): fix addIceCandidate crash on FF

* doc(JitsiConference): fix outdated comment

To be squashed with "ref(ChatRoom): remove unnecessary JingleSessionPC dependency"

* style(JitsiConference): rename arg to "jingleSession"

* feat(stats): add 'p2p' to 'transport'

The new p2p field will inform whether the transport comes from the peer
to peer type of connection or not.

* doc(TPC): describe local maps

* fix(P2P): multiplex between JVB and P2P ICE status

Will make sure that when in P2P mode the conference will be updated
with the ICE state coming from P2P and when in the JVB mode will get
the JVB one.

* doc(TPC): fixes docs and adds FIXME

* ref: use 'doesVideoMuteByStreamRemove'

* feat(P2P): stop P2P when ICE enters FAILED

The conference will switch back to the JVB connection when P2P
connection breaks (ICE enters failed state).

* feat(P2P): "connectivity-error" for ICE failed

Will use "connectivity-error" reason element name when ending P2P
session due to ICE failure.

* feat(xmpp): make P2P Stun servers configurable

STUN servers used in the P2P connection can be configured through
"p2pStunServers" option.

* ref(JitsiConference): use 'getActivePeerConnection'

* fix(P2P): re-create 'dtmfManager'

* ref(P2P): deal with ICE "completed" state

* ref(RTC): rename "owner" to "ownerEndpointId"

* fix(MungeLocalSdp): fix directions

* ref(ParticipantConnectionStatus): use for..of and () =>

* remove double 'l'

* ref: fix ESLint errors

* fix(MungeLocalSdp): adopt to new SdpTransformerUtil

* ref(MungeLocalSdp): use for .. of

* ref(SdpTransformUtil): remove "forEachSSRCAttr"

* fix(SDPDiffer): fix invalid "arrayEquals" call

* doc(MungeLocalSdp): add fixme

* fix(P2PEnabledConference): JVB tracks not added

* ref(JitsiConference): doc + rename mute methods

* ref(JitsiConference): adjust log level

* fix(JitsiConference): remove invalid eslint comments

Some mistake during rebase merge

* doc(JitsiConference): add FIXME

* ref(JitsiConferenceEventManager): stick to "tpc"

* ref(JitsiLocalTrack): use Set for "peerConnections"

* ref(JitsiLocalTrack): simplify expression

* ref(MungeLocalSdp): style + doc fixes

* ref: rename MungeLocalSdp to LocalSdpMunger

* ref(ParticipantConn..Status): rename method

* ref(SignalingLayerImpl): use Map and =>

* fix(strophe.jingle.js): minor style fixes + rename

* doc(XMPPEvents): typo

* doc(P2PEnabledConference): typo and style

* ref(P2PEnabledConference): rename methods

* ref(P2PEnabledConference): do not use "window"

* fix(P2PEnabledConference): cleanup deferred task

* ref(TPC): make options the last arg

* ref(TPC): use Map

* ref(TPC): syntax and other fixes...

* doc(ChatRoom): remove comment

* ref: remove P2PEnabledConference

* fix: remove JSUtil.js

* ref(LocalSdpMunger): re-use 'RtxModifier'

Reuses RtxModifier for injecting local RTX SSRCs as part of
the LocalSdpMunger logic.

* doc(LocalSdpMunger): remove confusing FIXME

* fix(TPC): setLocalDescription for FF

* fix(LocalSdpMunger): crash on react-native

* fix(JingleSessionPC): no events when ended

The instance once terminated should not emit connection state events.

* fix(P2P): do not start P2P on react-native

* fix: log meaningful error

Prior to this change you would see something like:
JitsiConference <error>: null

* fix(JingleSessionPC): no IQs once ended

* fix(JingleSessionPC): Jingle error logging

* fix: arguments order

* fix: make audio SSRC consistent

Audio SSRC needs to stay consistent between detach and attach operations
in order to avoid source-remove/source-add.

* fix(P2P): disable P2P on FF

There are problems with going back from P2P to JVB in FireFox. Other
participants will not see FF video. Looks like something related to
detach/attach.

* fix(JitsiConference): attach local tracks

Local tracks should be attached back to the JVB connection only
if the P2P was established.

* ref(JitsiConference): PR review fixes

ref(JitsiConference): else if

ref(JitsiConference): use getter

doc(JitsiConference): add comment

style(JitsiConference): remove extra line

log(JitsiConference): misleading msg

ref(JitsiConference): rename method

* ref(RTC): del _iteratePeerConnections

* ref: move getUfrag to SDPUtil

* fix(LocalSdpMunger): docs and if check

* fix(TPC): docs and typo

* ref(JingleSessionPC): PR review fixes

ref(JingleSessionPC): rename 'candidates'

ref(JitsiConference): remove extra check

ref(JitsiConference): rename isP2PEstablished

ref(JitsiConference): rename field (typo)

* doc(JitsiConferenceEventManager): typo

* ref(JitsiLocalTrack): rename var

* ref(JitsiConference): PR review fixes

ref(JitsiConference): rename var

doc(JitsiConference): add comment

doc(JitsiConference): add comment

doc(JitsiConference): fix comment

ref(JitsiConference): rename listener

ref(JitsiConference): rename var

* doc(RTC): remove duplicated arg description

doc(RTC): fill docs

* doc(SignalingLayerImpl): remove fixed FIXME

* ref(strophe.jingle.js): remove comment and break line

* style(TPC): formatting

doc(TPC): add FIXME

ref(TPC): remove unused code

doc(TPC): add docs

* doc(JingleSessionPC): mark "send" methods private

style(JingleSessionPC): extra lines